### PR TITLE
Remove fixed 16px height on check-box

### DIFF
--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -21,7 +21,6 @@ export const CheckboxContainer = styled.button`
 	position: relative;
 	border: none;
 	padding: 0;
-	height: 16px;
 	min-width: 0;
 	min-height: 16px;
 	background: transparent;


### PR DESCRIPTION
The button should be able to scale with the font-size of the label/title.
With the fixed 16px height, it ended up with a strange looking outline shape when focused.