### PR TITLE
Display children inside check-box component

### DIFF
--- a/catalog/checkbox/variations.md
+++ b/catalog/checkbox/variations.md
@@ -15,6 +15,7 @@ state: { isChecked: false }
 ```
 
 ### Custom theme
+
 ```react
 showSource: true
 state: { isChecked: false }
@@ -29,5 +30,22 @@ state: { isChecked: false }
 			border: 'plum',
 		}}
 	/>
+</CheckboxDemo>
+```
+
+### Custom label component
+
+```react
+showSource: true
+state: { isChecked: false }
+---
+<CheckboxDemo>
+	<Checkbox
+		onClick={() => setState({ isChecked: !state.isChecked })}
+		isChecked={state.isChecked}
+		type="button"
+	>
+		<span>No, click <b>me</b>!</span>
+	</Checkbox>
 </CheckboxDemo>
 ```

--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import * as Styled from './styled.jsx';
 
 /** Styled checkbox control (uses a button instead of an input) */
-export function Checkbox({ onClick, title, isChecked, theme, type }) {
+export function Checkbox({ onClick, title, isChecked, theme, type, children }) {
 	return (
 		<ThemeProvider theme={theme}>
 			<Styled.CheckboxContainer onClick={onClick} type={type}>
@@ -12,6 +12,7 @@ export function Checkbox({ onClick, title, isChecked, theme, type }) {
 					<Styled.CheckedIndicator isChecked={isChecked} />
 				</Styled.CheckboxDiv>
 				{title && <Styled.Label>{title}</Styled.Label>}
+				{children}
 			</Styled.CheckboxContainer>
 		</ThemeProvider>
 	);
@@ -24,6 +25,7 @@ Checkbox.propTypes = {
 	isChecked: PropTypes.bool,
 	theme: PropTypes.object,
 	type: PropTypes.string,
+	children: PropTypes.node,
 };
 
 Checkbox.defaultProps = {

--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -12,7 +12,7 @@ export function Checkbox({ onClick, title, isChecked, theme, type, children }) {
 					<Styled.CheckedIndicator isChecked={isChecked} />
 				</Styled.CheckboxDiv>
 				{title && <Styled.Label>{title}</Styled.Label>}
-				{children}
+				{children && <Styled.Label>{children}</Styled.Label>}
 			</Styled.CheckboxContainer>
 		</ThemeProvider>
 	);

--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -62,4 +62,8 @@ export const CheckedIndicator = styled.div`
 
 export const Label = styled.div`
 	margin-left: 22px;
+
+	& + & {
+		margin-left: 6px;
+	}
 `;


### PR DESCRIPTION
Would you consider merging this?
Here's the particular use case that I have in mind:

![image](https://user-images.githubusercontent.com/3677807/43985430-3fcaeec8-9cbc-11e8-9fa8-ae42be6d7dbe.png)

I'm passing in a <span> with a CSS class as a child component.

My alternative would be to include the text in the wrapper component, but then it wouldn't be as clickable as inside the button.