### PR TITLE
Add "flex: 1" to BlueBoxContent.

### DIFF
--- a/components/help-box/styled.jsx
+++ b/components/help-box/styled.jsx
@@ -3,7 +3,7 @@ import { fonts, colors, thickness } from '../../components/shared-styles';
 import { LightBulbH } from '../icons';
 
 export const BlueBoxContent = styled.div`
-	${fonts.ui16}
+	${fonts.ui16};
 
 	flex: 1;
 	padding: ${thickness.sixteen};

--- a/components/help-box/styled.jsx
+++ b/components/help-box/styled.jsx
@@ -5,6 +5,7 @@ import { LightBulbH } from '../icons';
 export const BlueBoxContent = styled.div`
 	${fonts.ui16}
 
+	flex: 1; 
 	padding: ${thickness.sixteen};
 	text-align: left;
 	color: ${colors.flGray};

--- a/components/help-box/styled.jsx
+++ b/components/help-box/styled.jsx
@@ -5,7 +5,7 @@ import { LightBulbH } from '../icons';
 export const BlueBoxContent = styled.div`
 	${fonts.ui16}
 
-	flex: 1; 
+	flex: 1;
 	padding: ${thickness.sixteen};
 	text-align: left;
 	color: ${colors.flGray};


### PR DESCRIPTION
Given that the container is a flexbox, and the sibling element has `flex: none`, I'm assuming we want `flex: 1` here.