### PR TITLE
Match the line height to the radio button height

### DIFF
--- a/components/bootstrap/custom.scss
+++ b/components/bootstrap/custom.scss
@@ -83,7 +83,11 @@ $custom-control-indicator-checked-color: $blue;
   @import "~bootstrap/scss/popover";  /* stylelint-disable-line */
   @import "~bootstrap/scss/grid";
 
-  .custom-control-label:before {
-    border: 1px solid $gray-600;
+  .custom-control-label {
+    line-height: $line-height-base;
+
+    &:before {
+      border: 1px solid $gray-600;
+    }
   }
 }


### PR DESCRIPTION
The radio button input has a min-height of `1.5em`, but the line height is was still at a `normal` value resulting in an offset label:

![alignment](https://user-images.githubusercontent.com/2214238/44496575-f8a17180-a629-11e8-9bf5-ff8f509e1aa0.png)

This adjusts the line height to `1.5`, which should generally match the height of `1.5em`.