### PR TITLE
Fix unclickable checkbox in Firefox

### DIFF
--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -18,7 +18,7 @@ export const CheckboxContainer = styled.button`
 	position: relative;
 	border: none;
 	padding: 0;
-	min-width: 0;
+	min-width: 16px;
 	min-height: 16px;
 	background: transparent;
 


### PR DESCRIPTION
This fixes an issue where if children/title are not provided, the checkbox gets a width of 0 and becomes unclickable in firefox.