### PR TITLE
Define box-sizing that should be used for loading spinner.

### DIFF
--- a/components/loading-spinner/styled.jsx
+++ b/components/loading-spinner/styled.jsx
@@ -14,6 +14,7 @@ export const Spinner = styled.div`
 	border: 0 solid ${props => props.theme.outerColor};
 	border-left-color: ${props => props.theme.innerColor};
 	border-radius: 50%;
+	box-sizing: content-box;
 	display: inline-block;
 	margin-left: 5px;
 	animation: ${spinTransform} 1.1s infinite linear;


### PR DESCRIPTION
![screen shot 2018-08-28 at 10 03 27 am](https://user-images.githubusercontent.com/11092733/44738405-adfc7b00-aaa9-11e8-82a4-a183956eeaee.png)

The spinner on the left demonstrates the styling when the page uses `box-sizing: border-box`. The spinner on the right is the intended look.