### PR TITLE
Add transparent border to `link` button variation

### DIFF
--- a/catalog/button/variations.md
+++ b/catalog/button/variations.md
@@ -32,6 +32,7 @@ showSource: true
 		Settings
 	</Button>
 	<Button primary square small renderIcon={<GearIcon />} />
+	<Button link square small renderIcon={<GearIcon />} />
 </ButtonDemo>
 ```
 

--- a/components/demo-button/styled.jsx
+++ b/components/demo-button/styled.jsx
@@ -111,7 +111,7 @@ export const variationMap = {
 		}
 `,
 	link: component => component.extend`
-		border: none;
+		border: 1px solid transparent;
 		background: none;
 		color: ${props => props.theme.defaultColor || buttonColors.default};
 		padding: 0;


### PR DESCRIPTION
This allows a `small square link` to be 32x32 instead of 30x32.