### PR TITLE
Fix button prop types.

### DIFF
--- a/components/button/anchor-button.jsx
+++ b/components/button/anchor-button.jsx
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
-import { BaseButton } from './base-button.jsx';
+import { BaseButton, SharedButtonPropTypes } from './base-button.jsx';
 import * as Styled from './styled.jsx';
 
 export class AnchorButton extends PureComponent {
-	static propTypes = BaseButton.propTypes;
+	static propTypes = SharedButtonPropTypes;
 
 	render() {
 		return <BaseButton baseComponent={Styled.Anchor} {...this.props} />;

--- a/components/button/base-button.jsx
+++ b/components/button/base-button.jsx
@@ -3,47 +3,51 @@ import PropTypes from 'prop-types';
 import { applyVariations } from '../utils';
 import * as Styled from './styled.jsx';
 
+export const SharedButtonPropTypes = {
+	/** The contents of the button (can be text, svg, or other element) */
+	children: PropTypes.node,
+	/** See the docs for how to override styles properly  */
+	className: PropTypes.string,
+	/** Condensed button padding. Uses same padding for horizontal and vertical. */
+	condensed: PropTypes.bool,
+	/** An optional theme */
+	theme: PropTypes.shape({
+		defaultColor: PropTypes.string,
+		hoverColor: PropTypes.string,
+		activeColor: PropTypes.string,
+		disabledColor: PropTypes.string,
+	}),
+	/** Style overrides */
+	styleOverrides: PropTypes.shape({
+		width: PropTypes.string,
+		fontSize: PropTypes.string,
+		padding: PropTypes.string,
+	}),
+	/** Primary button variation */
+	primary: PropTypes.bool,
+	/** Primary outline variation */
+	primaryOutline: PropTypes.bool,
+	/** Medium variation */
+	medium: PropTypes.bool,
+	/** Small variation */
+	small: PropTypes.bool,
+	/** Large variation */
+	large: PropTypes.bool,
+	/** Extra large variation */
+	extraLarge: PropTypes.bool,
+	/** Transparent with primary text variation */
+	primaryTransparent: PropTypes.bool,
+	/** Transparent with minor text variation */
+	minorTransparent: PropTypes.bool,
+	/** Enables rendering a display: flex span, needed for rendering SVG icons */
+	renderIcon: PropTypes.node,
+};
+
 export class BaseButton extends PureComponent {
 	static propTypes = {
+		...SharedButtonPropTypes,
 		/** This is only used by BaseButton not AnchorButton or Button */
-		baseComponent: PropTypes.element.isRequired,
-		/** The contents of the button (can be text, svg, or other element) */
-		children: PropTypes.node.isRequired,
-		/** See the docs for how to override styles properly  */
-		className: PropTypes.string,
-		/** Condensed button padding. Uses same padding for horizontal and vertical. */
-		condensed: PropTypes.bool,
-		/** An optional theme */
-		theme: PropTypes.shape({
-			defaultColor: PropTypes.string,
-			hoverColor: PropTypes.string,
-			activeColor: PropTypes.string,
-			disabledColor: PropTypes.string,
-		}),
-		/** Style overrides */
-		styleOverrides: PropTypes.shape({
-			width: PropTypes.string,
-			fontSize: PropTypes.string,
-			padding: PropTypes.string,
-		}),
-		/** Primary button variation */
-		primary: PropTypes.bool,
-		/** Primary outline variation */
-		primaryOutline: PropTypes.bool,
-		/** Medium variation */
-		medium: PropTypes.bool,
-		/** Small variation */
-		small: PropTypes.bool,
-		/** Large variation */
-		large: PropTypes.bool,
-		/** Extra large variation */
-		extraLarge: PropTypes.bool,
-		/** Transparent with primary text variation */
-		primaryTransparent: PropTypes.bool,
-		/** Transparent with minor text variation */
-		minorTransparent: PropTypes.bool,
-		/** Enables rendering a display: flex span, needed for rendering SVG icons */
-		renderIcon: PropTypes.node,
+		baseComponent: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/components/button/component.jsx
+++ b/components/button/component.jsx
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import * as Styled from './styled.jsx';
-import { BaseButton } from './base-button.jsx';
+import { BaseButton, SharedButtonPropTypes } from './base-button.jsx';
 
 /** Standard button with transition styles */
 export class Button extends PureComponent {
 	static propTypes = {
-		...BaseButton.propTypes,
+		...SharedButtonPropTypes,
 		/** The type of button (for instance, submit) */
 		type: PropTypes.string,
 	};


### PR DESCRIPTION
Rendering the `Button` or `AnchorButton` component yields the following warnings:
```
Warning: Failed prop type: The prop `baseComponent` is marked as required in `Button`, but its value is `undefined`.
```
and
```
Warning: Failed prop type: Invalid prop `baseComponent` of type `function` supplied to `BaseButton`, expected a single ReactElement.
```