### PR TITLE
Fix button prop types.

### DIFF
--- a/catalog/button/documentation.md
+++ b/catalog/button/documentation.md
@@ -3,5 +3,17 @@ This documentation is automatically generated from jsdoc comments.
 ```react
 noSource: true
 ---
-<DocgenTable component={BaseButton} displayName="Button and AnchorButton" />
+<DocgenTable component={BaseButton} displayName="Shared between Button and AnchorButton" />
+```
+
+```react
+noSource: true
+---
+<DocgenTable component={Button} displayName="Button" />
+```
+
+```react
+noSource: true
+---
+<DocgenTable component={AnchorButton} displayName="AnchorButton" />
 ```

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -115,7 +115,7 @@ const pages = [
 				path: '/button/documentation',
 				title: 'Button Documentation',
 				content: pageLoader(() => import('./button/documentation.md')),
-				imports: { BaseButton, DocgenTable },
+				imports: { BaseButton, Button, AnchorButton, DocgenTable },
 			},
 		],
 	},

--- a/components/button/anchor-button.jsx
+++ b/components/button/anchor-button.jsx
@@ -1,9 +1,14 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { BaseButton } from './base-button.jsx';
 import * as Styled from './styled.jsx';
 
 export class AnchorButton extends PureComponent {
-	static propTypes = BaseButton.propTypes;
+	static propTypes = {
+		...BaseButton.propTypes,
+		/** The destination the AnchorButton should link to. */
+		href: PropTypes.string,
+	};
 
 	render() {
 		return <BaseButton baseComponent={Styled.Anchor} {...this.props} />;

--- a/components/button/base-button.jsx
+++ b/components/button/base-button.jsx
@@ -5,10 +5,8 @@ import * as Styled from './styled.jsx';
 
 export class BaseButton extends PureComponent {
 	static propTypes = {
-		/** This is only used by BaseButton not AnchorButton or Button */
-		baseComponent: PropTypes.element.isRequired,
 		/** The contents of the button (can be text, svg, or other element) */
-		children: PropTypes.node.isRequired,
+		children: PropTypes.node,
 		/** See the docs for how to override styles properly  */
 		className: PropTypes.string,
 		/** Condensed button padding. Uses same padding for horizontal and vertical. */
@@ -51,13 +49,15 @@ export class BaseButton extends PureComponent {
 	};
 
 	render() {
-		const { children, theme, baseComponent, ...buttonProps } = this.props;
+		const { children, theme, ...buttonProps } = this.props;
 
+		/* eslint-disable react/prop-types */
 		const { component: MappedStyledComponent, filteredProps } = applyVariations(
-			baseComponent,
+			this.props.baseComponent, // this is required but we don't want it in the generated docs so don't include it above
 			Styled.variationMap,
 			buttonProps,
 		);
+		/* eslint-enable react/prop-types */
 
 		return (
 			<MappedStyledComponent theme={theme} {...filteredProps || {}}>


### PR DESCRIPTION
Rendering the `Button` or `AnchorButton` component yields the following warnings:
```
Warning: Failed prop type: The prop `baseComponent` is marked as required in `Button`, but its value is `undefined`.
```
and
```
Warning: Failed prop type: Invalid prop `baseComponent` of type `function` supplied to `BaseButton`, expected a single ReactElement.
```

For more discussion on the issue see https://github.com/Faithlife/styled-ui/pull/36.