### PR TITLE
Fix file name alignment.

### DIFF
--- a/components/files-section/file-item.jsx
+++ b/components/files-section/file-item.jsx
@@ -11,6 +11,7 @@ import * as Styled from './styled.jsx';
 
 const fileLabelButtonWidthOverride = {
 	width: '100%',
+	justifyContent: 'left',
 };
 
 export class FileItem extends PureComponent {

--- a/components/files-section/styled.jsx
+++ b/components/files-section/styled.jsx
@@ -44,7 +44,6 @@ export const FileInformation = styled.div`
 export const FileLabel = createEllipsizedComponent(styled.div`
 	${fonts.ui14};
 
-	text-align: left;
 	padding: 6px 0;
 `);
 


### PR DESCRIPTION
This uses the new style override introduced in https://github.com/Faithlife/styled-ui/commit/39abd4cf5bc2f91586dca0f6f057637d721673d5.