### PR TITLE
Remove unnecessary span from button contents.

### DIFF
--- a/components/button/base-button.jsx
+++ b/components/button/base-button.jsx
@@ -76,7 +76,7 @@ export const BaseButton = forwardClassRef(
 				>
 					<Styled.ButtonContents justifyContent={justifyContent}>
 						{this.props.icon}
-						{children != null && <span>{children}</span>}
+						{children}
 					</Styled.ButtonContents>
 				</MappedStyledComponent>
 			);


### PR DESCRIPTION
Currently the removed span overflows the bounds of `Styled.ButtonContents` which prevents the consumer from ellipsizing text of children elements:

<img width="845" alt="screen shot 2018-09-17 at 3 54 03 pm" src="https://user-images.githubusercontent.com/11092733/45655061-1def9700-ba93-11e8-9944-6b82b4359a38.png">

CC @etihwddot 