### PR TITLE
Change how we are styling SimpleModal to fix issue with reset styles

### DIFF
--- a/components/group-selector/modal/component.jsx
+++ b/components/group-selector/modal/component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '../../main.js';
+import { SimpleModal } from '../../simple-modal/component.jsx';
 import * as Styled from '../styled.jsx';
 import { SearchResult } from './search-result.jsx';
 import { CreateGroup } from './create-group.jsx';
@@ -200,82 +201,87 @@ export class GroupSelectorModal extends React.Component {
 		const disableButton = this.state.newChurchName === '' || this.state.newChurchLocation === '';
 
 		return (
-			<Styled.GroupSelectorModal isOpen={this.props.isOpen} onClose={this.toggle}>
-				<Styled.GroupSelectorModalBody innerRef={this.modalRef}>
-					{this.state.modalContent === 'main' && (
-						<Styled.MainModalContent>
-							<Styled.ModalTopGradientWrapper>
+			<Styled.GroupSelectorModal>
+				<SimpleModal isOpen={this.props.isOpen} onClose={this.toggle}>
+					<Styled.GroupSelectorModalBody innerRef={this.modalRef}>
+						{this.state.modalContent === 'main' && (
+							<Styled.MainModalContent>
 								<Styled.ModalTopGradient />
-							</Styled.ModalTopGradientWrapper>
-							<Styled.ModalTitle>Find Your Church</Styled.ModalTitle>
-							<Styled.ModalSubtitle>in the Faithlife Church Directory</Styled.ModalSubtitle>
-							<Styled.CreateGroupWrapper fixed={this.state.createGroupFixed}>
-								<Styled.CreateGroupBackground scrollWidthDelta={this.state.scrollWidthDelta}>
-									<CreateGroup
-										onChurchNameInputChange={this.handleChurchNameInputChange}
-										onChurchLocationInputChange={this.handleChurchLocationInputChange}
-										newChurchName={this.state.newChurchName}
-										newChurchLocation={this.state.newChurchLocation}
-										showRequiredStars={this.state.createGroupFixed}
-									/>
-									<Styled.CreateGroupButtonWrapper>
-										<Styled.CreateGroupButtonText>
-											Don't see your church?
-										</Styled.CreateGroupButtonText>
-										<Button small primary disabled={disableButton} onClick={this.createGroupClick}>
-											Create
+								<Styled.ModalTitle>Find Your Church</Styled.ModalTitle>
+								<Styled.ModalSubtitle>in the Faithlife Church Directory</Styled.ModalSubtitle>
+								<Styled.CreateGroupWrapper fixed={this.state.createGroupFixed}>
+									<Styled.CreateGroupBackground scrollWidthDelta={this.state.scrollWidthDelta}>
+										<CreateGroup
+											onChurchNameInputChange={this.handleChurchNameInputChange}
+											onChurchLocationInputChange={this.handleChurchLocationInputChange}
+											newChurchName={this.state.newChurchName}
+											newChurchLocation={this.state.newChurchLocation}
+											showRequiredStars={this.state.createGroupFixed}
+										/>
+										<Styled.CreateGroupButtonWrapper>
+											<Styled.CreateGroupButtonText>
+												Don't see your church?
+											</Styled.CreateGroupButtonText>
+											<Button
+												small
+												primary
+												disabled={disableButton}
+												onClick={this.createGroupClick}
+											>
+												Create
+											</Button>
+										</Styled.CreateGroupButtonWrapper>
+									</Styled.CreateGroupBackground>
+								</Styled.CreateGroupWrapper>
+								<Styled.SearchResultsContainer
+									style={{ marginTop: this.state.resultsTopMargin }}
+									fixed={this.state.createGroupFixed}
+									innerRef={this.searchResultsRef}
+								>
+									{this.getSearchResults()}
+								</Styled.SearchResultsContainer>
+							</Styled.MainModalContent>
+						)}
+						{this.state.modalContent === 'admin' && (
+							<Styled.SecondaryModalContent>
+								<Styled.SecondaryModalText>
+									<Styled.SearchResultBoldText>Admin</Styled.SearchResultBoldText>
+									<span> membership is neccessarry to perform this action.</span>
+								</Styled.SecondaryModalText>
+								<Styled.SecondaryModalText>
+									Contact a group administrator to request Admin membership
+								</Styled.SecondaryModalText>
+								<Styled.SecondaryModalButtonContainer>
+									<Styled.SecondaryModalButtonWrapper>
+										<Button primary onClick={this.redirectToGroup}>
+											Request access
 										</Button>
-									</Styled.CreateGroupButtonWrapper>
-								</Styled.CreateGroupBackground>
-							</Styled.CreateGroupWrapper>
-							<Styled.SearchResultsContainer
-								style={{ marginTop: this.state.resultsTopMargin }}
-								fixed={this.state.createGroupFixed}
-								innerRef={this.searchResultsRef}
-							>
-								{this.getSearchResults()}
-							</Styled.SearchResultsContainer>
-						</Styled.MainModalContent>
-					)}
-					{this.state.modalContent === 'admin' && (
-						<Styled.SecondaryModalContent>
-							<Styled.SecondaryModalText>
-								<Styled.SearchResultBoldText>Admin</Styled.SearchResultBoldText>
-								<span> membership is neccessarry to perform this action.</span>
-							</Styled.SecondaryModalText>
-							<Styled.SecondaryModalText>
-								Contact a group administrator to request Admin membership
-							</Styled.SecondaryModalText>
-							<Styled.SecondaryModalButtonContainer>
-								<Styled.SecondaryModalButtonWrapper>
-									<Button primary onClick={this.redirectToGroup}>
-										Request access
-									</Button>
-								</Styled.SecondaryModalButtonWrapper>
-								<Button onClick={this.resetModalState}>Cancel</Button>
-							</Styled.SecondaryModalButtonContainer>
-						</Styled.SecondaryModalContent>
-					)}
-					{this.state.modalContent === 'change' && (
-						<Styled.SecondaryModalContent>
-							<Styled.SecondaryModalText>
-								This group type must be set to{' '}
-								<Styled.SearchResultBoldText>"Church"</Styled.SearchResultBoldText>
-							</Styled.SecondaryModalText>
-							<Styled.SecondaryModalText>
-								Visit the group settings page to change
-							</Styled.SecondaryModalText>
-							<Styled.SecondaryModalButtonContainer>
-								<Styled.SecondaryModalButtonWrapper>
-									<Button primary onClick={this.redirectToGroup}>
-										Change to Church
-									</Button>
-								</Styled.SecondaryModalButtonWrapper>
-								<Button onClick={this.resetModalState}>Cancel</Button>
-							</Styled.SecondaryModalButtonContainer>
-						</Styled.SecondaryModalContent>
-					)}
-				</Styled.GroupSelectorModalBody>
+									</Styled.SecondaryModalButtonWrapper>
+									<Button onClick={this.resetModalState}>Cancel</Button>
+								</Styled.SecondaryModalButtonContainer>
+							</Styled.SecondaryModalContent>
+						)}
+						{this.state.modalContent === 'change' && (
+							<Styled.SecondaryModalContent>
+								<Styled.SecondaryModalText>
+									This group type must be set to{' '}
+									<Styled.SearchResultBoldText>"Church"</Styled.SearchResultBoldText>
+								</Styled.SecondaryModalText>
+								<Styled.SecondaryModalText>
+									Visit the group settings page to change
+								</Styled.SecondaryModalText>
+								<Styled.SecondaryModalButtonContainer>
+									<Styled.SecondaryModalButtonWrapper>
+										<Button primary onClick={this.redirectToGroup}>
+											Change to Church
+										</Button>
+									</Styled.SecondaryModalButtonWrapper>
+									<Button onClick={this.resetModalState}>Cancel</Button>
+								</Styled.SecondaryModalButtonContainer>
+							</Styled.SecondaryModalContent>
+						)}
+					</Styled.GroupSelectorModalBody>
+				</SimpleModal>
 			</Styled.GroupSelectorModal>
 		);
 	}

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { SimpleModal } from '../simple-modal/component.jsx';
 import { resetStyles } from '../utils/index.js';
 
 export const GroupSelector = styled.div`
@@ -144,16 +143,21 @@ export const DropdownButtonContainer = styled.div`
 	justify-content: center;
 `;
 
-export const GroupSelectorModal = styled(SimpleModal)`
+export const GroupSelectorModal = styled.div`
 	${resetStyles};
 	position: relative;
 `;
 
 export const ModalTopGradient = styled.div`
-	margin-left: 24px;
-	margin-right: 24px;
+	padding-left: 24px;
+	padding-right: 24px;
+	padding-top: 24px;
 	height: 100%;
 	background: white;
+	position: absolute;
+	top: 0px;
+	width: 100%;
+	height: 30px;
 	z-index: 2;
 	box-shadow: 0px 10px 8px -4px white;
 `;
@@ -162,7 +166,7 @@ export const ModalTopGradientWrapper = styled.div`
 	position: absolute;
 	top: 0px;
 	width: 100%;
-	height: 30px;
+	height: 40px;
 	z-index: 2;
 `;
 
@@ -175,7 +179,7 @@ export const ModalTitle = styled.p`
 `;
 
 export const ModalSubtitle = styled.p`
-	margin: 4px 0 24px 0;
+	margin-top: 4px;
 	font-size: 16px;
 	text-align: center;
 	line-height: 1.2;
@@ -189,13 +193,12 @@ export const MainModalContent = styled.div`
 export const CreateGroupWrapper = styled.div`
 	position: ${props => (props.fixed ? 'absolute' : 'relative')};
 	width: 100%;
-	box-sizing: border-box;
 	z-index: 1;
 
 	${props =>
 		props.fixed &&
 		`
-		top: 20px;
+		top: 17px;
 		`};
 `;
 
@@ -212,7 +215,6 @@ export const SearchResultsContainer = styled.div`
 	width: 100%;
 	padding-left: 12px;
 	padding-right: 12px;
-	box-sizing: border-box;
 	z-index: ${props => (props.fixed ? 0 : 2)};
 	height: 100%;
 `;
@@ -255,7 +257,7 @@ export const GroupSelectorModalBody = styled.div`
 `;
 
 export const SearchResult = styled.div`
-	height: 76px;
+	height: 100px;
 	background-color: white;
 	margin-bottom: 7px;
 	padding: 12px;


### PR DESCRIPTION
Due to how I was styling SimpleModal, I was actually not getting the styling I thought I was. Thus, the reset styles was not working and the `box-sizing` was set incorrectly. This also means that during development, some sizes were done with `content-box` instead of `border-box`.

This fixes the reset styles, and cleans up the css for the affected components.