### PR TITLE
Cleanup group Selector

### DIFF
--- a/components/group-selector/avatar.jsx
+++ b/components/group-selector/avatar.jsx
@@ -1,24 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import * as Styled from './styled.jsx';
 import * as icons from './icons.jsx';
 
-export function Avatar({ avatarUrl, name, kind, size = '32px' }) {
+export function Avatar({ avatarUrl, name, kind, size = 32 }) {
+	let child;
 	if (avatarUrl) {
-		return (
-			<img style={{ borderRadius: '3px', width: size, height: size }} src={avatarUrl} alt={name} />
-		);
+		child = <Styled.AvatarImage size={size} src={avatarUrl} alt={name} />;
+	} else {
+		const Icon = storedIcons.get(kind) || getIconForGroupKind(kind);
+
+		child = <Icon viewBox="0 0 76 76" />;
 	}
 
-	const Icon = storedIcons.get(kind) || getIconForGroupKind(kind);
-
-	return <Icon style={{ borderRadius: '3px', width: size, height: size }} viewBox="0 0 76 76" />;
+	return <Styled.AvatarWrapper size={size}>{child}</Styled.AvatarWrapper>;
 }
 
 Avatar.propTypes = {
 	avatarUrl: PropTypes.string,
 	name: PropTypes.string,
 	kind: PropTypes.string,
-	size: PropTypes.string,
+	size: PropTypes.number,
 };
 
 const storedIcons = new Map();

--- a/components/group-selector/dropdown.jsx
+++ b/components/group-selector/dropdown.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Button } from '../../components/main.js';
 import * as Styled from './styled.jsx';
 import { SimpleGroup } from './simple-group.jsx';
-import { Avatar } from './avatar.jsx';
 
 export class GroupDropdown extends React.PureComponent {
 	static propTypes = {
@@ -110,11 +109,20 @@ export class GroupDropdown extends React.PureComponent {
 			/>
 		));
 
-		const { name, kind, avatarUrl } = this.props.selectedGroup;
+		const { name, kind, groupId, avatarUrl } = this.props.selectedGroup;
 
 		return (
 			<Styled.DropdownContainer innerRef={this.dropdownRef}>
-				<Styled.SelectedGroupContainer>
+				<Styled.SelectedGroup onClick={this.handleDropdownToggle} onKeyDown={this.handleKeyPress}>
+					<SimpleGroup
+						groupId={groupId}
+						name={name}
+						kind={kind}
+						isSelected={false}
+						isHovered={false}
+						avatarUrl={avatarUrl}
+						disableHover
+					/>
 					<Styled.DownArrow
 						xmlns="http://www.w3.org/2000/svg"
 						width="12"
@@ -123,23 +131,17 @@ export class GroupDropdown extends React.PureComponent {
 					>
 						<polygon fill="#888" points="8 6 4 9.5 4 2.5" transform="rotate(90 6 6)" />
 					</Styled.DownArrow>
-					<Styled.SelectedGroup onClick={this.handleDropdownToggle} onKeyDown={this.handleKeyPress}>
-						<Styled.SelectedGroupAvatar>
-							<Avatar avatarUrl={avatarUrl} name={name} kind={kind} />
-						</Styled.SelectedGroupAvatar>
-						<Styled.SelectedGroupText>{this.props.selectedGroup.name}</Styled.SelectedGroupText>
-					</Styled.SelectedGroup>
-					{this.state.isDropdownOpen && (
-						<Styled.DropdownWrapper>
-							<Styled.DropdownGroupsContainer>{groups}</Styled.DropdownGroupsContainer>
-							<Styled.DropdownButtonContainer>
-								<Button small primaryOutline onClick={this.handleDropdownButtonClick}>
-									Find or Add Church
-								</Button>
-							</Styled.DropdownButtonContainer>
-						</Styled.DropdownWrapper>
-					)}
-				</Styled.SelectedGroupContainer>
+				</Styled.SelectedGroup>
+				{this.state.isDropdownOpen && (
+					<Styled.DropdownWrapper>
+						<Styled.DropdownGroupsContainer>{groups}</Styled.DropdownGroupsContainer>
+						<Styled.DropdownButtonContainer>
+							<Button small primaryOutline onClick={this.handleDropdownButtonClick}>
+								Find or Add Church
+							</Button>
+						</Styled.DropdownButtonContainer>
+					</Styled.DropdownWrapper>
+				)}
 			</Styled.DropdownContainer>
 		);
 	}

--- a/components/group-selector/modal/search-result.jsx
+++ b/components/group-selector/modal/search-result.jsx
@@ -151,7 +151,7 @@ export class SearchResult extends React.PureComponent {
 		return (
 			<Styled.SearchResult>
 				<Styled.SearchResultAvatar>
-					<Avatar avatarUrl={avatarUrl} name={name} kind={kind} size="40px" />
+					<Avatar avatarUrl={avatarUrl} name={name} kind={kind} size={40} />
 				</Styled.SearchResultAvatar>
 				<Styled.SearchResultContent>
 					<div>

--- a/components/group-selector/simple-group.jsx
+++ b/components/group-selector/simple-group.jsx
@@ -3,32 +3,44 @@ import PropTypes from 'prop-types';
 import { Avatar } from './avatar.jsx';
 import * as Styled from './styled.jsx';
 
-export function SimpleGroup({ onClick, groupId, avatarUrl, name, kind, isSelected, isHovered }) {
+export function SimpleGroup({
+	onClick,
+	groupId,
+	avatarUrl,
+	name,
+	kind,
+	isSelected,
+	isHovered,
+	disableHover,
+}) {
 	let backgroundColor = 'white';
 	if (isSelected) {
 		backgroundColor = '#ebf7ff';
-	} else if (isHovered) {
+	} else if (!disableHover && isHovered) {
 		backgroundColor = '#ebf7ff';
 	}
 
 	return (
-		<Styled.SimpleGroup color={backgroundColor} onClick={() => onClick(groupId, name)}>
+		<Styled.SimpleGroup
+			color={backgroundColor}
+			disableHover={disableHover}
+			onClick={() => onClick && onClick(groupId, name)}
+		>
 			<Styled.SimpleGroupAvatar>
 				<Avatar avatarUrl={avatarUrl} name={name} kind={kind} />
 			</Styled.SimpleGroupAvatar>
-			<Styled.SimpleGroupInfo>
-				<Styled.SimpleGroupName>{name}</Styled.SimpleGroupName>
-			</Styled.SimpleGroupInfo>
+			<Styled.SimpleGroupName>{name}</Styled.SimpleGroupName>
 		</Styled.SimpleGroup>
 	);
 }
 
 SimpleGroup.propTypes = {
-	onClick: PropTypes.func.isRequired,
 	groupId: PropTypes.number.isRequired,
-	avatarUrl: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	kind: PropTypes.string.isRequired,
+	disableHover: PropTypes.bool,
 	isSelected: PropTypes.bool.isRequired,
 	isHovered: PropTypes.bool.isRequired,
+	avatarUrl: PropTypes.string,
+	onClick: PropTypes.func,
 };

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -48,6 +48,19 @@ export const SelectedGroup = styled.button`
 	align-items: center;
 `;
 
+export const AvatarWrapper = styled.div`
+	border-radius: 3px;
+	width: ${props => props.size}px;
+	height: ${props => props.size}px;
+	overflow: hidden;
+`;
+
+export const AvatarImage = styled.img`
+	display: block;
+	width: ${props => props.size}px;
+	height: ${props => props.size}px;
+`;
+
 export const SimpleGroup = styled.div`
 	text-align: left;
 	padding: 6px;

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -147,7 +147,7 @@ export const ModalTopGradientWrapper = styled.div`
 	z-index: 2;
 `;
 
-export const ModalTitle = styled.p`
+export const ModalTitle = styled.div`
 	font-size: 32px;
 	margin: 5px 0 0 0;
 	font-weight: 800;
@@ -155,7 +155,7 @@ export const ModalTitle = styled.p`
 	text-align: center;
 `;
 
-export const ModalSubtitle = styled.p`
+export const ModalSubtitle = styled.div`
 	margin-top: 4px;
 	font-size: 16px;
 	text-align: center;
@@ -209,8 +209,9 @@ export const CreateGroupButtonWrapper = styled.div`
 	margin: 16px 0 16px 0;
 `;
 
-export const CreateGroupButtonText = styled.p`
+export const CreateGroupButtonText = styled.div`
 	font-size: 16px;
+	margin: 16px 0 16px 0;
 	color: #575251;
 `;
 
@@ -222,7 +223,7 @@ export const CreateGroupLabel = styled.div`
 	color: #575251;
 `;
 
-export const CreateGroupRequiredStar = styled.p`
+export const CreateGroupRequiredStar = styled.div`
 	display: inline;
 	color: #d94848;
 `;
@@ -306,7 +307,7 @@ export const SecondaryModalContent = styled.div`
 	padding-bottom: 12px;
 `;
 
-export const SecondaryModalText = styled.p`
+export const SecondaryModalText = styled.div`
 	font-size: 14px;
 	margin: 0px;
 `;

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -27,39 +27,47 @@ export const GroupInputButton = styled.div`
 	}
 `;
 
-export const SimpleGroup = styled.div`
-	text-align: left;
-	padding: 4px 6px 4px 6px;
-	background-color: ${props => props.color};
-	cursor: pointer;
-
-	&:hover {
-		background-color: #ebf7ff;
-	}
+export const DownArrow = styled.svg`
+	position: absolute;
+	right: 8px;
 `;
 
-export const SelectedGroupAvatar = styled.div`
-	width: 32px;
-	height: 32px;
-	float: left;
-	margin: 5px 0 6px 1px;
+export const SelectedGroup = styled.button`
+	width: 100%;
+	height: 44px;
+	position: relative;
+	cursor: pointer;
+	border-radius: 6px;
+	padding: 0px;
+	background-color: white;
 	border-radius: 3px;
+	border: 0;
+	cursor: pointer;
+	color: black;
+	display: flex;
+	align-items: center;
+`;
+
+export const SimpleGroup = styled.div`
+	text-align: left;
+	padding: 6px;
+	background-color: ${props => props.color};
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	${props =>
+		!props.disableHover &&
+		`&:hover {
+		background-color: #ebf7ff;
+	}`};
 `;
 
 export const SimpleGroupAvatar = styled.div`
 	width: 32px;
 	height: 32px;
-	display: inline-block;
-	vertical-align: middle;
 	margin-right: 6px;
 	border-radius: 3px;
-`;
-
-export const SimpleGroupInfo = styled.div`
-	display: inline-block;
-	vertical-align: middle;
-	max-width: 200px;
-	width: 76%;
+	overflow: hidden;
 `;
 
 export const SimpleGroupName = styled.div`
@@ -67,51 +75,6 @@ export const SimpleGroupName = styled.div`
 	color: #585250;
 	white-space: nowrap;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	font-family: 'Source Sans Pro';
-`;
-
-export const SimpleGroupMembershipLine = styled.div`
-	font-size: 10px;
-	color: #95908f;
-`;
-
-export const SelectedGroupContainer = styled.div`
-	position: relative;
-	height: 44px;
-	cursor: pointer;
-	border-radius: 6px;
-`;
-
-export const DownArrow = styled.svg`
-	position: absolute;
-	float: right;
-	top: 15px;
-	right: 8px;
-`;
-
-export const SelectedGroup = styled.button`
-	width: 100%;
-	height: 100%;
-	padding-left: 5px;
-	padding-bottom: 0px;
-	background-color: white;
-	border-radius: 3px;
-	border: 0;
-	cursor: pointer;
-	color: black;
-`;
-
-export const SelectedGroupText = styled.div`
-	font-size: 13px;
-	line-height: 18px;
-	padding-top: 13px;
-	float: left;
-	margin-left: 6px;
-	width: 64%;
-	text-align: left;
-	overflow: hidden;
-	white-space: nowrap;
 	text-overflow: ellipsis;
 	font-family: 'Source Sans Pro';
 `;
@@ -126,7 +89,8 @@ export const DropdownGroupsContainer = styled.div`
 `;
 
 export const DropdownContainer = styled.div`
-	margin-bottom: 8px;
+	position: relative;
+	height: 44px;
 `;
 
 export const DropdownWrapper = styled.div`


### PR DESCRIPTION
This PR contains a number of fixes:

One is it removed some duplicated code and switched from using float and hardcoded padding to center things to using flex box.

Also, if removed some styles that were being set directly on components instead of using styled components.

Lastly, making a complicated component that works on everyone's web page is hard. 'p' elements were used in this component and were getting useragent styles with margins such that it looked nice in the catalog, but could look bad elsewhere. Switching to divs works around this and seems better since the 'p' elements weren't really being used for paragraphs of text.

@dustinsoftware 