### PR TITLE
Expose SimpleModal and provide documentation

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -18,6 +18,7 @@ import {
 	GroupSelector,
 	GroupSelectorModal,
 	ShareDialog,
+	SimpleModal,
 } from '../components/main.js';
 import { BaseButton } from '../components/button/base-button.jsx';
 import { BootstrapContainer } from '../components/utils';
@@ -329,6 +330,50 @@ const pages = [
 				title: 'Modal Documentation',
 				content: pageLoader(() => import('./modal/documentation.md')),
 				imports: { Modal, DocgenTable },
+			},
+		],
+	},
+	{
+		title: 'SimpleModal',
+		pages: [
+			{
+				path: '/simple-modal/variations',
+				title: 'Simple Modal Variations',
+				content: pageLoader(() => import('./simple-modal/variations.md')),
+				imports: {
+					SimpleModal,
+					Button,
+					SimpleModalDemo: styled.div`
+						font-family: 'Source Sans Pro';
+						color: #333333;
+
+						.modal-content {
+							margin-top: 20px;
+							margin-bottom: 20px;
+							width: 300px;
+							height: 200px;
+							display: flex;
+							flex-direction: column;
+							align-items: center;
+							justify-content: space-around;
+						}
+
+						.message {
+							background-color: #eeeeee;
+							padding: 20px;
+						}
+
+						.success {
+							width: 60px;
+						}
+					`,
+				},
+			},
+			{
+				path: '/simple-modal/documentation',
+				title: 'SimpleModal Documentation',
+				content: pageLoader(() => import('./simple-modal/documentation.md')),
+				imports: { SimpleModal, DocgenTable },
 			},
 		],
 	},

--- a/catalog/simple-modal/documentation.md
+++ b/catalog/simple-modal/documentation.md
@@ -1,0 +1,7 @@
+This documentation is automatically generated from jsdoc comments.
+
+```react
+noSource: true
+---
+<DocgenTable component={SimpleModal} />
+```

--- a/catalog/simple-modal/variations.md
+++ b/catalog/simple-modal/variations.md
@@ -1,0 +1,28 @@
+## SimpleModal
+
+Simple modal does not have any internal padding or features. Only contains an absolute positioned close button in the corner.
+
+```react
+showSource: true
+state: { modal: false, value: '' }
+---
+<SimpleModalDemo>
+	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
+	<SimpleModal
+		isOpen={state.modal}
+		onClose={() => setState({ modal: false })}
+	>
+		<div className="modal-content">
+			<svg className="success" x="0px" y="0px"
+				viewBox="0 0 426.667 426.667">
+				<path style={{fill: "#6AC259" }} d="M213.333,0C95.518,0,0,95.514,0,213.333s95.518,213.333,213.333,213.333
+				c117.828,0,213.333-95.514,213.333-213.333S331.157,0,213.333,0z M174.199,322.918l-93.935-93.931l31.309-31.309l62.626,62.622
+				l140.894-140.898l31.309,31.309L174.199,322.918z"/>
+			</svg>
+			<div>Success!</div>
+			<div className="message">Wide content that goes all the way to the edge.</div>
+		</div>
+	</SimpleModal>
+</SimpleModalDemo>
+```
+

--- a/components/main.js
+++ b/components/main.js
@@ -9,6 +9,7 @@ export { AnchorButton } from './button/anchor-button.jsx';
 export { Bootstrap } from './bootstrap';
 export { LoadingSpinner } from './loading-spinner/component.jsx';
 export { Modal, ModalFooter } from './modal';
+export { SimpleModal } from './simple-modal/component.jsx';
 export { HelpBox } from './help-box/component.jsx';
 export { Collapse } from './collapse/component.jsx';
 export { FilesSection } from './files-section/component.jsx';


### PR DESCRIPTION
This component was added in a prior PR but was only used internally (Mostly due to not having any documentation). Now it has documentation and is exposed publicly.