### PR TITLE
Fix group name truncation when name is larger than selector

### DIFF
--- a/catalog/group-selector/variations.md
+++ b/catalog/group-selector/variations.md
@@ -7,7 +7,7 @@ state: {
 		name: 'Michaels Test Church',
 		groupId: 1,
 		kind: 'church',
-		avatarUrl: '',
+		avatarUrl: 'https://avatars.logoscdn.com/451/6830451_f896e509e7504b33812f0f6bf086ffa8.jpg',
 		relationshipKind: 'participant',
 		membershipKind: 'admin',
 		claimable: false,

--- a/components/group-selector/dropdown.jsx
+++ b/components/group-selector/dropdown.jsx
@@ -114,15 +114,17 @@ export class GroupDropdown extends React.PureComponent {
 		return (
 			<Styled.DropdownContainer innerRef={this.dropdownRef}>
 				<Styled.SelectedGroup onClick={this.handleDropdownToggle} onKeyDown={this.handleKeyPress}>
-					<SimpleGroup
-						groupId={groupId}
-						name={name}
-						kind={kind}
-						isSelected={false}
-						isHovered={false}
-						avatarUrl={avatarUrl}
-						disableHover
-					/>
+					<Styled.SelectedSimpleGroupWrapper>
+						<SimpleGroup
+							groupId={groupId}
+							name={name}
+							kind={kind}
+							isSelected={false}
+							isHovered={false}
+							avatarUrl={avatarUrl}
+							disableHover
+						/>
+					</Styled.SelectedSimpleGroupWrapper>
 					<Styled.DownArrow
 						xmlns="http://www.w3.org/2000/svg"
 						width="12"

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -80,7 +80,6 @@ export const SimpleGroupAvatar = styled.div`
 	height: 32px;
 	margin-right: 6px;
 	border-radius: 3px;
-	overflow: hidden;
 `;
 
 export const SimpleGroupName = styled.div`

--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -91,6 +91,11 @@ export const SimpleGroupName = styled.div`
 	font-family: 'Source Sans Pro';
 `;
 
+export const SelectedSimpleGroupWrapper = styled.div`
+	padding-right: 20px;
+	width: 100%;
+`;
+
 export const DropdownGroupsContainer = styled.div`
 	max-height: 205px;
 	overflow: auto;


### PR DESCRIPTION
This PR fixes truncation of the group name. It was going beyond the bounds of the selector and overlapping the triangle icon.

Plus:
Fixes an issue where when the selector was really constrained, the avatar would get cut off, which we never want.

Adds a sample avatarUrl to the sample data in the catalog to better show off the selector.