### PR TITLE
Split input onChange from typeahead onchange in inferred-typeahead

### DIFF
--- a/catalog/text-input/inferred.md
+++ b/catalog/text-input/inferred.md
@@ -13,7 +13,7 @@ import '@faithlife/styled-ui/dist/text-input.css';
 
 ```react
 showSource: false
-state: { value: 'Washington', confirmed: false }
+state: { defaultValue: 'Washington', confirmed: false }
 ---
 <div>
 	<FormGroup>
@@ -24,7 +24,33 @@ state: { value: 'Washington', confirmed: false }
 			onConfirm={value => { setState({ confirmed: true })}}
 			options={['Washington','California','Texas']}
 			placeholder="Choose a state..."
-			defaultInputValue={state.value}
+			defaultInputValue={state.defaultValue}
+		/>
+	</FormGroup>
+</div>
+```
+
+### Inferred typeahead with input onChange
+
+```
+import { InferredTypeahead } from '@faithlife/styled-ui/dist/text-input.js';
+import '@faithlife/styled-ui/dist/text-input.css';
+```
+
+```react
+showSource: false
+state: { value: '', confirmed: false, options: ['Washington','California','Texas'] }
+---
+<div>
+	<FormGroup>
+		<Label>Looking for: {state.inputValue} - selected: {state.value}</Label>
+		<InferredTypeahead
+			confidence={state.confirmed ? null : 0.9}
+			onInputChange={inputValue => { setState({ inputValue }); }}
+			onChange={value => { setState({ value, confirmed: true }); }}
+			onConfirm={value => { setState({ confirmed: true }); }}
+			options={state.options}
+			placeholder="Choose a state..."
 		/>
 	</FormGroup>
 </div>

--- a/components/text-input/inferred-typeahead.jsx
+++ b/components/text-input/inferred-typeahead.jsx
@@ -19,6 +19,8 @@ export class InferredTypeahead extends Component {
 		/** String to display in the confidence tooltip. Defaults to Heuristic algorithm */
 		confidenceSource: PropTypes.string,
 		/** Function called when the input value is changed */
+		onInputChange: PropTypes.func,
+		/** Function called when the typeahead value is selected */
 		onChange: PropTypes.func,
 		/** Function called when the OK button is clicked or an input value is confirmed */
 		onConfirm: PropTypes.func.isRequired,
@@ -37,6 +39,7 @@ export class InferredTypeahead extends Component {
 			className,
 			onConfirm,
 			onChange,
+			onInputChange,
 			...inputProps
 		} = this.props;
 
@@ -52,7 +55,7 @@ export class InferredTypeahead extends Component {
 					{props => (
 						<StyledTypeahead
 							inferred={props.inferred}
-							onInputChange={onChange}
+							onInputChange={onInputChange}
 							onChange={onChange}
 							{...inputProps}
 						/>


### PR DESCRIPTION
The typeahead onChange returns and array while the input onChange returns a string. It's also worth noting the inferred typeahead doesn't really work with `multiple` set to true but I have not fixed that here.