### PR TITLE
Add ARIA attributes to styled checkboxes and radios

### DIFF
--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -7,7 +7,13 @@ import * as Styled from './styled.jsx';
 export function Checkbox({ onClick, title, isChecked, theme, type, children, className }) {
 	return (
 		<ThemeProvider theme={theme}>
-			<Styled.CheckboxContainer onClick={onClick} type={type} className={className}>
+			<Styled.CheckboxContainer
+				onClick={onClick}
+				type={type}
+				className={className}
+				role={'checkbox'}
+				aria-checked={isChecked}
+			>
 				<Styled.CheckboxDiv>
 					<Styled.CheckedIndicator isChecked={isChecked} />
 				</Styled.CheckboxDiv>

--- a/components/radio/component.jsx
+++ b/components/radio/component.jsx
@@ -7,7 +7,13 @@ import * as Styled from './styled.jsx';
 export function Radio({ onClick, title, isChecked, theme, type, children, className }) {
 	return (
 		<ThemeProvider theme={theme}>
-			<Styled.RadioContainer onClick={onClick} type={type} className={className}>
+			<Styled.RadioContainer
+				onClick={onClick}
+				type={type}
+				className={className}
+				role={'radio'}
+				aria-checked={isChecked}
+			>
 				<Styled.RadioDiv>
 					<Styled.CheckedIndicator isChecked={isChecked} />
 				</Styled.RadioDiv>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role

- [x] role="checkbox"
- [x] aria-checked (except for "mixed" which is not supported)
- [ ] tabindex="0" (inherited from `button`)
- [ ] aria-readonly (not supported)
- [x] onclick
- [ ] onKeyPress (inherited from `button`)