### PR TITLE
Fix modals with really long content overflowing the screen size

### DIFF
--- a/catalog/modal/variations.md
+++ b/catalog/modal/variations.md
@@ -190,3 +190,23 @@ state: { modal: false, value: '' }
 	</Modal>
 </ModalDemo>
 ```
+
+## Modal with really long content
+
+```react
+showSource: true
+state: { modal: false, value: '' }
+---
+<ModalDemo>
+	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
+	<Modal
+		isOpen={state.modal}
+		onClose={() => setState({ modal: false })}
+		title="Lots of content"
+	>
+		<div className="content">
+			{JSON.stringify(new Array(1000))}
+		</div>
+	</Modal>
+</ModalDemo>
+```

--- a/components/modal/styled.jsx
+++ b/components/modal/styled.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { thickness, fonts, colors } from '../shared-styles';
+import { resetStyles } from '../utils';
 
 export const Label = styled.label`
 	display: block;
@@ -8,9 +9,11 @@ export const Label = styled.label`
 `;
 
 export const Modal = styled.div`
+	${resetStyles};
 	margin: auto;
 	width: fit-content;
 	height: fit-content;
+	max-width: calc(100% - 16px);
 	max-height: 80%;
 	padding: ${thickness.twentyfour};
 	background-color: ${props => props.theme.background};
@@ -23,9 +26,11 @@ export const Modal = styled.div`
 `;
 
 export const ModalContent = styled.div`
+	max-width: 100%;
 	max-height: 80%;
 	overflow-x: hidden;
 	overflow-y: auto;
+	overflow-wrap: break-word;
 `;
 
 export const ModalHeader = styled.div`


### PR DESCRIPTION
Sets a max-width on the modal, so that it can no longer overflow the page on the x axis. Also adds a few other css properties to make sure the content doesn't overflow the modal.