### PR TITLE
Add Popover component

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -17,6 +17,7 @@ import {
 	FilesSection,
 	DropZone,
 	SimpleModal,
+	Popover,
 } from '../components/main.js';
 import { BaseButton } from '../components/button/base-button.jsx';
 import { BootstrapContainer } from '../components/utils';
@@ -472,6 +473,7 @@ const pages = [
 					`,
 					IconsContainer: styled.div`
 						color: #a8a8a8;
+
 						> * {
 							margin: 0 12px;
 						}
@@ -533,6 +535,39 @@ const pages = [
 				title: 'Share Dialog Documentation',
 				content: pageLoader(() => import('./share-dialog/documentation.md')),
 				imports: { ShareDialog, DocgenTable },
+			},
+		],
+	},
+	{
+		title: 'Popover',
+		pages: [
+			{
+				path: '/popover/variations',
+				title: 'Popover Variations',
+				content: pageLoader(() => import('./popover/variations.md')),
+				imports: {
+					Button,
+					Popover,
+					PopoverDemo: styled.div`
+						display: flex;
+						align-items: flex-start;
+						justify-content: space-between;
+					`,
+					PopoverOverflowDemo: styled.div`
+						display: flex;
+						align-items: flex-start;
+						justify-content: space-around;
+						position: relative;
+						overflow: hidden;
+						padding-top: 20px;
+					`,
+				},
+			},
+			{
+				path: '/popover/documentation',
+				title: 'Popover Documentation',
+				content: pageLoader(() => import('./popover/documentation.md')),
+				imports: { Popover, DocgenTable },
 			},
 		],
 	},

--- a/catalog/popover/documentation.md
+++ b/catalog/popover/documentation.md
@@ -1,0 +1,7 @@
+This documentation is automatically generated from jsdoc comments.
+
+ ```react
+noSource: true
+---
+<DocgenTable component={Popover} />
+```

--- a/catalog/popover/variations.md
+++ b/catalog/popover/variations.md
@@ -1,0 +1,68 @@
+## Popover
+
+ ```react
+showSource: true
+state: { isOpen: false}
+---
+<PopoverDemo>
+	<Button id="basicButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.basicButton}>Hello!</Popover>
+</PopoverDemo>
+```
+
+ ## Placement
+
+ ```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverDemo>
+	<Button id="topButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show Popovers!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.topButton} placement="top">Hello!</Popover>
+
+	<Button id="bottomButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show Popovers!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.bottomButton} placement="bottom">Hello!</Popover>
+
+	<Button id="leftButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show Popovers!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.leftButton} placement="left">Hello!</Popover>
+
+	<Button id="rightButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show Popovers!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.rightButton} placement="right">Hello!</Popover>
+</PopoverDemo>
+```
+
+ ## Options
+
+ ```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverDemo>
+	<Button id="themeButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.themeButton} theme={{ backgroundColor: '#ebf7ff', border: 'black solid 1px' }}>Hello!</Popover>
+
+	<Button id="styleButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.styleButton} styleOverrides={{ padding: '18px', hideShadow: true, width: '200px' }}>Hello!</Popover>
+	
+	<Button id="arrowButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.arrowButton} showArrow>Hello!</Popover>
+
+	<Button id="delayButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover w/ a delay!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.delayButton} delay={1000}>Hello!</Popover>
+</PopoverDemo>
+```
+
+ ## Using container prop
+
+ ```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverOverflowDemo>
+	<Button id="inlineButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.inlineButton} placement="top">I'm inline</Popover>
+
+	<Button id="bodyButton" primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
+	<Popover isOpen={state.isOpen} anchorElement={window.bodyButton} placement="top" breakOut>I'm thinking with portals!</Popover>
+</PopoverOverflowDemo>
+```

--- a/components/main.js
+++ b/components/main.js
@@ -15,3 +15,4 @@ export { HelpBox } from './help-box/component.jsx';
 export { Collapse } from './collapse/component.jsx';
 export { FilesSection } from './files-section/component.jsx';
 export { DropZone } from './drop-zone/component.jsx';
+export { Popover } from './popover/component.jsx';

--- a/components/popover/component.jsx
+++ b/components/popover/component.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Popper from '@material-ui/core/Popper';
+import { ThemeProvider } from 'styled-components';
+import * as Styled from './styled.jsx';
+
+const ElementType = typeof HTMLElement !== 'undefined' ? HTMLElement : Object;
+
+export class Popover extends React.Component {
+	static propTypes = {
+		/** Is the popover open */
+		isOpen: PropTypes.bool,
+		/** Element the popup is anchored to */
+		anchorElement: PropTypes.instanceOf(ElementType),
+		/** Where on the target the popover renders */
+		placement: PropTypes.string,
+		/** If the popup needs to escape the local stacking context */
+		breakOut: PropTypes.bool,
+		/** Show popover arrow */
+		showArrow: PropTypes.bool,
+		/** Delay on popover showing in milliseconds*/
+		delay: PropTypes.number,
+		/** Not all modifiers are shown. Refer to https://popper.js.org/popper-documentation.html#modifiers for a full list*/
+		modifiers: PropTypes.shape({
+			arrow: PropTypes.object,
+			offset: PropTypes.shape({
+				enabled: PropTypes.bool,
+				offset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+			}),
+			preventOverflow: PropTypes.shape({
+				padding: PropTypes.number,
+				boundariesElement: PropTypes.oneOfType([PropTypes.string, ElementType]),
+			}),
+			flip: PropTypes.shape({
+				enabled: PropTypes.bool,
+				behavior: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+				padding: PropTypes.number,
+				boundariesElement: PropTypes.oneOfType([PropTypes.string, ElementType]),
+			}),
+		}),
+		styleOverrides: PropTypes.shape({
+			hideShadow: PropTypes.bool,
+			width: PropTypes.string,
+			padding: PropTypes.string,
+		}),
+		theme: PropTypes.shape({
+			backgroundColor: PropTypes.string,
+			textColor: PropTypes.string,
+			boder: PropTypes.string,
+		}),
+		/** Contents of the Popover */
+		children: PropTypes.node,
+	};
+
+	static defaultProps = {
+		placement: 'bottom',
+		theme: { backgroundColor: '#ffffff' },
+		styleOverrides: {},
+	};
+
+	state = { isOpen: this.props.isOpen && this.props.delay === 0 };
+
+	componentDidMount() {
+		this.onOpenStateChange();
+	}
+
+	componentDidUpdate() {
+		this.onOpenStateChange();
+		if (this.arrow.current !== this.prevArrow) {
+			this.prevArrow = this.arrow.current;
+			this.forceUpdate();
+		}
+	}
+
+	componentWillUnmount() {
+		clearTimeout(this.timeout);
+	}
+
+	onOpenStateChange() {
+		if (this.props.isOpen !== this.state.isOpen && this.timeout == null) {
+			this.timeout = setTimeout(() => {
+				this.setState({ isOpen: this.props.isOpen }, () => {
+					this.timeout = null;
+				});
+			}, this.props.delay);
+		}
+	}
+
+	timeout = null;
+	arrow = React.createRef();
+
+	getOptions = () => ({
+		placement: this.props.placement,
+		eventsEnabled: true,
+		positionFixed: false,
+		modifiers: {
+			...this.props.modifiers,
+			arrow: {
+				...(this.props.modifiers && this.props.modifiers.arrow),
+				enabled: this.arrow.current != null,
+				element: this.arrow.current,
+			},
+		},
+	});
+
+	render() {
+		return (
+			<ThemeProvider theme={this.props.theme}>
+				<Popper
+					anchorEl={this.props.anchorElement}
+					disablePortal={!this.props.breakOut}
+					open={this.state.isOpen}
+					popperOptions={this.getOptions()}
+				>
+					<Styled.PopoverContent
+						styleOverrides={this.props.styleOverrides}
+						showArrow={this.props.showArrow}
+					>
+						{this.props.children}
+						{this.props.showArrow && (
+							<Styled.Arrow innerRef={this.arrow} styleOverrides={this.props.styleOverrides} />
+						)}
+					</Styled.PopoverContent>
+				</Popper>
+			</ThemeProvider>
+		);
+	}
+}

--- a/components/popover/styled.jsx
+++ b/components/popover/styled.jsx
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+import { colors, thickness } from '../shared-styles';
+
+const arrowWidth = '10px';
+const maxWidth = 300;
+
+export const PopoverContent = styled.div`
+	position: relative;
+	padding: ${({ styleOverrides }) => styleOverrides.padding || thickness.twelve};
+	max-width: ${({ styleOverrides }) => styleOverrides.width || maxWidth}px;
+	background-color: ${({ theme }) => theme.backgroundColor};
+	border-radius: 3px;
+	text-align: center;
+	border: ${({ theme }) => (theme.border ? theme.border : 'none')};
+	box-shadow: ${({ styleOverrides }) => (styleOverrides.hideShadow ? 'none' : colors.boxShadow)};
+	${({ theme }) => (theme.textColor ? `color: ${theme.textColor}` : '')};
+	${({ showArrow }) =>
+		showArrow
+			? `
+	[x-placement*='top'] & {
+		margin-bottom: ${arrowWidth};
+	}
+
+	[x-placement*='bottom'] & {
+		margin-top: ${arrowWidth};
+	}
+
+	[x-placement*='right'] & {
+		margin-left: ${arrowWidth};
+	}
+
+	[x-placement*='left'] & {
+		margin-right: ${arrowWidth};
+	}
+	`
+			: ''};
+`;
+
+export const Arrow = styled.div`
+	width: 25px;
+	height: 25px;
+	position: absolute;
+	overflow: hidden;
+
+	&::after {
+		content: '';
+		border: ${({ theme }) => (theme.border ? theme.border : 'none')};
+		position: absolute;
+		width: ${arrowWidth};
+		height: ${arrowWidth};
+		background: ${({ theme }) => theme.backgroundColor};
+		transform: translate(-50%, -50%) rotate(45deg);
+		box-shadow: ${({ styleOverrides }) => (styleOverrides.hideShadow ? 'none' : colors.boxShadow)};
+	}
+
+	[x-placement*='top'] & {
+		top: 100%;
+
+		&::after {
+			top: 0;
+		}
+	}
+
+	[x-placement*='bottom'] & {
+		bottom: 100%;
+
+		&::after {
+			top: 100%;
+		}
+	}
+
+	[x-placement*='right'] & {
+		right: 100%;
+
+		&::after {
+			top: 50%;
+			left: 100%;
+		}
+	}
+
+	[x-placement*='left'] & {
+		left: 100%;
+
+		&::after {
+			top: 50%;
+			left: 0;
+		}
+	}
+`;

--- a/components/shared-styles/index.js
+++ b/components/shared-styles/index.js
@@ -76,6 +76,8 @@ export const colors = {
 	redDark: '#bd2929',
 
 	borderColor: ' #a8a8a8',
+
+	boxShadow: '0 4px 4px 0 rgba(0, 0, 0, 0.12), 0 0 4px 0 rgba(0, 0, 0, 0.12)',
 };
 
 export const inputColors = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"styled-components": "^3.2.5"
 	},
 	"dependencies": {
+		"@material-ui/core": "^3.5.1",
 		"clipboard": "^2.0.1",
 		"lodash.debounce": "^4.0.8",
 		"prop-types": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,6 +107,24 @@
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
 
+"@babel/runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.0.0":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -199,6 +217,44 @@
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.3.tgz#65682e68a82701c70eefb38d7f941a2c0bfa90de"
 
+"@material-ui/core@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.5.1.tgz#365d1c392d3df3b37295db0548f4cca501034e69"
+  dependencies:
+    "@babel/runtime" "7.1.2"
+    "@material-ui/utils" "^3.0.0-alpha.0"
+    "@types/jss" "^9.5.6"
+    "@types/react-transition-group" "^2.0.8"
+    brcast "^3.0.1"
+    classnames "^2.2.5"
+    csstype "^2.5.2"
+    debounce "^1.1.0"
+    deepmerge "^2.0.1"
+    dom-helpers "^3.2.1"
+    hoist-non-react-statics "^3.0.0"
+    is-plain-object "^2.0.4"
+    jss "^9.3.3"
+    jss-camel-case "^6.0.0"
+    jss-default-unit "^8.0.2"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-vendor-prefixer "^7.0.0"
+    keycode "^2.1.9"
+    normalize-scroll-left "^0.1.2"
+    popper.js "^1.14.1"
+    prop-types "^15.6.0"
+    react-event-listener "^0.6.2"
+    react-transition-group "^2.2.1"
+    recompose "0.28.0 - 0.30.0"
+    warning "^4.0.1"
+
+"@material-ui/utils@^3.0.0-alpha.0":
+  version "3.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.0.tgz#506fcaf531a9a8f58a73ff2d3dfaa36c0f238506"
+  dependencies:
+    "@babel/runtime" "7.1.2"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -222,6 +278,30 @@
     parse-repo "^1.0.4"
     shelljs "^0.8.1"
     yargs "^11.0.0"
+
+"@types/jss@^9.5.6":
+  version "9.5.7"
+  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.7.tgz#fa57a6d0b38a3abef8a425e3eb6a53495cb9d5a0"
+  dependencies:
+    csstype "^2.0.0"
+    indefinite-observable "^1.0.1"
+
+"@types/prop-types@*":
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
+
+"@types/react-transition-group@^2.0.8":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.14.tgz#afd0cd785a97f070b55765e9f9d76ff568269001"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.7.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.4.tgz#0d21b6137fc68b433309ecffda28649797330fbd"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
@@ -1797,6 +1877,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+brcast@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -2198,6 +2282,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
 character-entities-html4@^1.0.0:
   version "1.1.2"
@@ -2837,6 +2925,12 @@ css-url-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/css-url-regex/-/css-url-regex-1.1.0.tgz#83834230cc9f74c457de59eebd1543feeb83b7ec"
 
+css-vendor@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -2895,6 +2989,10 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+csstype@^2.0.0, csstype@^2.2.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
+
 csstype@^2.5.2:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
@@ -2944,6 +3042,10 @@ date-now@^0.1.4:
 dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
+
+debounce@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
 
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -3103,6 +3205,10 @@ deep-extend@^0.6.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deepmerge@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -4105,7 +4211,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4975,6 +5081,12 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
+hoist-non-react-statics@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5123,6 +5235,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -5265,6 +5381,12 @@ imurmurhash@^0.1.4:
 in-publish@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
+indefinite-observable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-1.0.1.tgz#09915423cc8d6f7eb1cb7882ad134633c9a6edc3"
+  dependencies:
+    symbol-observable "1.0.4"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -5571,6 +5693,10 @@ is-hexadecimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+
 is-jpg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-jpg/-/is-jpg-1.0.1.tgz#296d57fdd99ce010434a7283e346ab9a1035e975"
@@ -5817,6 +5943,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.4.3, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -5925,6 +6055,44 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jss-camel-case@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.1.0.tgz#ccb1ff8d6c701c02a1fed6fb6fb6b7896e11ce44"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
+jss-default-unit@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
+
+jss-global@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
+
+jss-nested@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
+  dependencies:
+    warning "^3.0.0"
+
+jss-props-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
+
+jss-vendor-prefixer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
+  dependencies:
+    css-vendor "^0.3.8"
+
+jss@^9.3.3:
+  version "9.8.7"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
+    warning "^3.0.0"
+
 jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
@@ -5934,6 +6102,10 @@ jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+keycode@^2.1.9:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -6248,6 +6420,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6875,6 +7053,10 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
+normalize-scroll-left@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
+
 normalize-selector@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
@@ -7422,6 +7604,10 @@ pngquant-bin@^4.0.0:
 popper.js@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+
+popper.js@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -8139,11 +8325,19 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-event-listener@^0.6.2:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.4.tgz#d0ea5ed897da1a796616c44b5a8758898140f203"
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
 react-is@^16.3.1, react-is@^16.3.2:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
-react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -8219,6 +8413,15 @@ react-transition-group@^2.2.0, react-transition-group@^2.3.1:
     dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
+
+react-transition-group@^2.2.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^2.4.0:
   version "2.4.0"
@@ -8357,6 +8560,17 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+"recompose@0.28.0 - 0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -8406,6 +8620,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -9578,6 +9796,14 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
 table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
@@ -10277,6 +10503,12 @@ ware@^1.2.0:
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Based primarily on the work already done by Korbin [here](https://github.com/Faithlife/styled-ui/pull/68), but using `material-ui/popper` instead of  `react-popper`. This allows for a simpler API that still provides all the functionality of the original.