### PR TITLE
Add experimental table from giving

### DIFF
--- a/catalog/experimental-table/documentation.md
+++ b/catalog/experimental-table/documentation.md
@@ -1,0 +1,7 @@
+This documentation is automatically generated from jsdoc comments.
+
+```react
+noSource: true
+---
+<DocgenTable component={ExperimentalTable} />
+```

--- a/catalog/experimental-table/variations.md
+++ b/catalog/experimental-table/variations.md
@@ -1,0 +1,98 @@
+## Experimental Table
+
+```react
+showSource: true
+state: { }
+---
+<TableDemo>
+<ExperimentalTable
+	headings={[ { heading: 'UserId', }, { heading: 'name' } ]}
+	data={[
+		{ key: 1, rowData: [ {content: '1'}, {content: 'Bob'} ] },
+		{ key: 2, rowData: [ {content: '2'}, {content: 'Jim'} ] },
+		{ key: 3, rowData: [ {content: '3'}, {content: 'Eli'} ] }
+	]}
+/>
+</TableDemo>
+```
+
+### Clickable Rows
+
+```react
+showSource: true
+state: { }
+---
+<TableDemo>
+<ExperimentalTable
+	headings={[ { heading: 'UserId', }, { heading: 'name' } ]}
+	data={[
+		{ key: 1, rowData: [ {content: '1'}, {content: 'Bob'} ], onClickRow: () => { alert('Bob'); } },
+		{ key: 2, rowData: [ {content: '2'}, {content: 'Jim'} ], onClickRow: () => { alert('Jim'); } },
+		{ key: 3, rowData: [ {content: '3'}, {content: 'Eli'} ], onClickRow: () => { alert('Eli'); } }
+	]}
+/>
+</TableDemo>
+```
+
+### Sortable Columns
+
+```react
+showSource: true
+state: {
+	sortOrder: 'ASC',
+	sortField: 'UserId',
+	tableHeadings: [
+		{
+			heading: 'UserId',
+		},
+		{ heading: 'Name' },
+	],
+	tableData: [
+		{
+			key: 1,
+			rowData: [{ content: '1' }, { content: 'Bob' }],
+		},
+		{
+			key: 2,
+			rowData: [{ content: '2' }, { content: 'Jim' }],
+		},
+		{
+			key: 3,
+			rowData: [{ content: '3' }, { content: 'Eli' }],
+		},
+	],
+}
+---
+<TableDemo>
+	<ExperimentalTable
+		headings={state.tableHeadings.map(x => ({
+			heading: x.heading,
+			sortOrder: state.sortOrder,
+			onClick: state.sortField === x.heading ?
+			() => setState(prevState => ({ sortOrder: prevState.sortOrder === ExperimentalTable.sortOrders.ASCENDING
+					? ExperimentalTable.sortOrders.DESCENDING
+					: ExperimentalTable.sortOrders.ASCENDING,
+			}))
+			: null }))}
+		data={state.tableData.sort((a,b) => { return state.sortOrder === ExperimentalTable.sortOrders.ASCENDING ? a.key - b.key : b.key-a.key; })}
+	/>
+</TableDemo>
+```
+
+### Custom data cell styles
+
+```react
+showSource: true
+state: { }
+---
+<TableDemo>
+<ExperimentalTable
+	headings={[ { heading: 'UserId', }, { heading: 'name' } ]}
+	data={[
+		{ key: 1, rowData: [ {content: '1'}, {content: 'Bob', style: { color: 'red' }} ], onClickRow: () => { alert('Bob'); } },
+		{ key: 2, rowData: [ {content: '2'}, {content: 'Jim', style: { color: 'blue' }} ], onClickRow: () => { alert('Jim'); } },
+		{ key: 3, rowData: [ {content: '3'}, {content: 'Eli', style: { color: 'green' }} ], onClickRow: () => { alert('Eli'); } }
+	]}
+/>
+</TableDemo>
+```

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -612,31 +612,31 @@ const components = [
 				content: pageLoader(() => import('./date-picker-input/documentation.md')),
 				imports: { DatePickerInput, DocgenTable },
 			},
+		],
+	},
+	{
+		title: 'Experimental Table',
+		pages: [
 			{
-				title: 'Experimental Table',
-				pages: [
-					{
-						path: '/experimental-table/variations',
-						title: 'Experimental Table Variations',
-						content: pageLoader(() => import('./experimental-table/variations.md')),
-						imports: {
-							TableDemo: styled.div`
-								font-family: Source Sans Pro;
-								background-color: white;
-								border-radius: 2px;
-								box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.12), 0 0 4px 0 rgba(0, 0, 0, 0.12);
-								padding: 20px 0;
-							`,
-							ExperimentalTable,
-						},
-					},
-					{
-						path: '/experimental-table/documentation',
-						title: 'Experimental Table Documentation',
-						content: pageLoader(() => import('./experimental-table/documentation.md')),
-						imports: { ExperimentalTable, DocgenTable },
-					},
-				],
+				path: '/experimental-table/variations',
+				title: 'Experimental Table Variations',
+				content: pageLoader(() => import('./experimental-table/variations.md')),
+				imports: {
+					TableDemo: styled.div`
+						font-family: Source Sans Pro;
+						background-color: white;
+						border-radius: 2px;
+						box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.12), 0 0 4px 0 rgba(0, 0, 0, 0.12);
+						padding: 20px 0;
+					`,
+					ExperimentalTable,
+				},
+			},
+			{
+				path: '/experimental-table/documentation',
+				title: 'Experimental Table Documentation',
+				content: pageLoader(() => import('./experimental-table/documentation.md')),
+				imports: { ExperimentalTable, DocgenTable },
 			},
 		],
 	},

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -27,6 +27,7 @@ import {
 	DatePicker,
 	DatePickerInput,
 	DatePeriodPicker,
+	ExperimentalTable,
 } from '../components/main';
 import { BaseButton } from '../components/button/base-button';
 import { Typeahead, InferredText, InferredTypeahead } from '../components/text-input';
@@ -606,10 +607,36 @@ const components = [
 				},
 			},
 			{
-				path: 'date-picker-input/documentation',
+				path: '/date-picker-input/documentation',
 				title: 'Date Picker Input Documentation',
 				content: pageLoader(() => import('./date-picker-input/documentation.md')),
 				imports: { DatePickerInput, DocgenTable },
+			},
+			{
+				title: 'Experimental Table',
+				pages: [
+					{
+						path: '/experimental-table/variations',
+						title: 'Experimental Table Variations',
+						content: pageLoader(() => import('./experimental-table/variations.md')),
+						imports: {
+							TableDemo: styled.div`
+								font-family: Source Sans Pro;
+								background-color: white;
+								border-radius: 2px;
+								box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.12), 0 0 4px 0 rgba(0, 0, 0, 0.12);
+								padding: 20px 0;
+							`,
+							ExperimentalTable,
+						},
+					},
+					{
+						path: '/experimental-table/documentation',
+						title: 'Experimental Table Documentation',
+						content: pageLoader(() => import('./experimental-table/documentation.md')),
+						imports: { ExperimentalTable, DocgenTable },
+					},
+				],
 			},
 		],
 	},

--- a/components/experimental-table/component.jsx
+++ b/components/experimental-table/component.jsx
@@ -3,9 +3,15 @@ import PropTypes from 'prop-types';
 import { ArrowUp } from '../../components/icons';
 import * as Styled from './styled.jsx';
 
+/**
+ * ExperimentalTable:
+ * Simple table component (not meant as a replacement for ag-grid). It takes a set an arry of headings and an arry of rows.
+ * Order matters for headings and rows (data will be rendered in the order given)
+ */
 export class ExperimentalTable extends Component {
 	/* eslint-disable react/no-unused-prop-types */
 	static propTypes = {
+		/** Table headings. This can be null or empty for no headings */
 		headings: PropTypes.arrayOf(
 			PropTypes.shape({
 				heading: PropTypes.string.isRequired,
@@ -14,13 +20,16 @@ export class ExperimentalTable extends Component {
 				sortOrder: PropTypes.string,
 			}),
 		),
+		/** Table data. Each row should be provided with a key for proper list handling in react. See https://reactjs.org/docs/lists-and-keys.html */
 		data: PropTypes.arrayOf(
 			PropTypes.shape({
 				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 				rowData: PropTypes.arrayOf(
 					PropTypes.shape({
 						content: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.node]),
+						/** override/cell-specific styling */
 						style: PropTypes.object,
+						className: PropTypes.string,
 					}),
 				),
 				onClickRow: PropTypes.func,
@@ -60,7 +69,11 @@ export class ExperimentalTable extends Component {
 			? []
 			: data.map(({ key, rowData, onClickRow }) => {
 					const tds = rowData.map((cellData, i) => (
-						<Styled.TableCell key={`${key}-${i}`} style={cellData.style}>
+						<Styled.TableCell
+							key={`${key}-${i}`}
+							className={cellData.className}
+							style={cellData.style}
+						>
 							{cellData.content}
 						</Styled.TableCell>
 					));

--- a/components/experimental-table/component.jsx
+++ b/components/experimental-table/component.jsx
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ArrowUp } from '../../components/icons';
+import * as Styled from './styled.jsx';
+
+export class ExperimentalTable extends Component {
+	/* eslint-disable react/no-unused-prop-types */
+	static propTypes = {
+		headings: PropTypes.arrayOf(
+			PropTypes.shape({
+				heading: PropTypes.string.isRequired,
+				className: PropTypes.string,
+				onClick: PropTypes.func,
+				sortOrder: PropTypes.string,
+			}),
+		),
+		data: PropTypes.arrayOf(
+			PropTypes.shape({
+				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+				rowData: PropTypes.arrayOf(
+					PropTypes.shape({
+						content: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.node]),
+						style: PropTypes.object,
+					}),
+				),
+				onClickRow: PropTypes.func,
+			}),
+		),
+	};
+	/* eslint-enable react/no-unused-prop-types */
+
+	static sortOrders = {
+		ASCENDING: 'ASC',
+		DESCENDING: 'DESC',
+	};
+
+	static getDerivedStateFromProps(props) {
+		const { headings, data } = props;
+		const tableHeadings = !headings
+			? []
+			: headings.map(content => {
+					const orderIcon =
+						content.sortOrder === ExperimentalTable.sortOrders.ASCENDING ? (
+							<ArrowUp />
+						) : (
+							<ArrowUp style={{ transform: 'rotateX(180deg)' }} />
+						);
+					return (
+						<Styled.Heading
+							key={content.heading}
+							sortable={!!content.onClick}
+							onClick={content.onClick ? content.onClick : null}
+						>
+							{content.onClick ? orderIcon : ''} {content.heading}
+						</Styled.Heading>
+					);
+			  });
+
+		const tableData = !data
+			? []
+			: data.map(({ key, rowData, onClickRow }) => {
+					const tds = rowData.map((cellData, i) => (
+						<Styled.TableCell key={`${key}-${i}`} style={cellData.style}>
+							{cellData.content}
+						</Styled.TableCell>
+					));
+					return (
+						<Styled.TableRow key={key} onClick={onClickRow}>
+							{tds}
+						</Styled.TableRow>
+					);
+			  });
+
+		return { tableHeadings, tableData };
+	}
+
+	state = {};
+
+	render() {
+		const { tableHeadings, tableData } = this.state;
+
+		const tableHeader = !tableHeadings ? (
+			undefined
+		) : (
+			<Styled.TableHeader>
+				<Styled.HeaderRow>{tableHeadings}</Styled.HeaderRow>
+			</Styled.TableHeader>
+		);
+
+		const tableBody = !tableData ? undefined : <tbody>{tableData}</tbody>;
+
+		return (
+			<Styled.Table>
+				{tableHeader}
+				{tableBody}
+			</Styled.Table>
+		);
+	}
+}

--- a/components/experimental-table/index.js
+++ b/components/experimental-table/index.js
@@ -1,0 +1,1 @@
+export { ExperimentalTable } from './component';

--- a/components/experimental-table/styled.jsx
+++ b/components/experimental-table/styled.jsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 import { thickness, colors } from '../shared-styles';
+import { resetStyles } from '../utils';
 
 export const Table = styled.table`
+	${resetStyles};
 	border-collapse: collapse;
 	width: 100%;
 `;

--- a/components/experimental-table/styled.jsx
+++ b/components/experimental-table/styled.jsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+import { thickness, colors } from '../shared-styles';
+
+export const Table = styled.table`
+	border-collapse: collapse;
+	width: 100%;
+`;
+
+export const TableCell = styled.td`
+	text-overflow: ellipsis;
+	overflow: hidden;
+	flex: 1;
+`;
+
+export const TableHeader = styled.thead`
+	text-align: left;
+`;
+
+export const TableRow = styled.tr`
+	display: flex;
+	align-items: center;
+	padding: ${thickness.twelve} ${thickness.sixteen};
+	border-bottom: 1px solid ${colors.borderColor};
+	align-items: normal;
+
+	${props =>
+		props.onClick
+			? `cursor: pointer; &:hover, &:active, &:focus { background-color: ${colors.gray8} }`
+			: ''};
+`;
+
+export const HeaderRow = styled.tr`
+	display: flex;
+	align-items: center;
+	padding: ${thickness.twelve} ${thickness.sixteen};
+	background-color: ${colors.gray4};
+	border-width: 1px 0 1px 0;
+	border-color: ${colors.borderColor};
+	border-style: solid;
+`;
+
+export const Heading = styled.th`
+	flex: 1;
+	font-weight: 700;
+`;
+
+export const SortableHeading = styled.th`
+	flex: 1;
+	font-weight: 700;
+	${props =>
+		props.sortable
+			? `cursor: pointer; &:hover, &:active, &:focus { background-color: ${colors.gray8} }`
+			: ''};
+`;

--- a/components/icons/index.js
+++ b/components/icons/index.js
@@ -241,3 +241,9 @@ export const ShareIcon = props => (
 		</g>
 	</svg>
 );
+
+export const ArrowUp = props => (
+	<svg {...props} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+		<polygon fill="currentColor" points="4 6 8 9.5 8 2.5" transform="rotate(90 6 6)" />
+	</svg>
+);

--- a/components/main.js
+++ b/components/main.js
@@ -3,6 +3,7 @@
 // We could use tree-shaking in the future to prune out unused exports,
 // but not all projects are able to use that right now.
 
+// Exports should be alphabetically sorted
 export { AnchorButton } from './button/anchor-button';
 export { Bootstrap } from './bootstrap';
 export { Button } from './button';
@@ -12,6 +13,7 @@ export { DatePicker } from './date-picker';
 export { DatePickerInput } from './date-picker-input';
 export { DatePeriodPicker } from './date-period-picker';
 export { DropZone } from './drop-zone';
+export { ExperimentalTable } from './experimental-table';
 export { FilesSection } from './files-section';
 export { HelpBox } from './help-box';
 export { Input } from './input';
@@ -20,4 +22,3 @@ export { Modal, ModalFooter } from './modal';
 export { Popover, PopoverManager, PopoverReference, Tooltip } from './popover';
 export { Radio } from './radio';
 export { SimpleModal } from './simple-modal';
-export { ExperimentalTable } from './experimental-table';

--- a/components/main.js
+++ b/components/main.js
@@ -20,3 +20,4 @@ export { Modal, ModalFooter } from './modal';
 export { Popover, PopoverManager, PopoverReference, Tooltip } from './popover';
 export { Radio } from './radio';
 export { SimpleModal } from './simple-modal';
+export { ExperimentalTable } from './experimental-table';


### PR DESCRIPTION
This is pretty much a direct port of what we have in giving. I'm open to dramatically altering the API, but it was copied over into stores recently so I thought it made sense to add it to styled-ui. I would see this not as a replacement for ag-grid, but as a simpler alternative.