### PR TITLE
Prevent popover arrow from interfering with mouse events

### DIFF
--- a/components/popover/styled.jsx
+++ b/components/popover/styled.jsx
@@ -27,6 +27,7 @@ export const PopoverContent = styled.div`
 	text-align: center;
 	border: ${({ styleOverrides }) => (styleOverrides.border ? styleOverrides.border : 'none')};
 	box-shadow: ${({ styleOverrides }) => (styleOverrides.hideShadow ? 'none' : colors.boxShadow)};
+	white-space: normal;
 	${({ theme }) => (theme.textColor ? `color: ${theme.textColor}` : '')};
 `;
 
@@ -35,6 +36,7 @@ export const Arrow = styled.div`
 	height: 25px;
 	position: absolute;
 	overflow: hidden;
+	pointer-events: none;
 
 	&::after {
 		content: '';


### PR DESCRIPTION
In the [current tooltip example](https://faithlife.github.io/styled-ui/#/popover/variations?a=tooltip) if you hover your mouse directly below the popover arrow it will cause the tooltip to close.