### PR TITLE
Scale button icons to match font size

### DIFF
--- a/catalog/button/variations.md
+++ b/catalog/button/variations.md
@@ -28,6 +28,9 @@ showSource: true
 showSource: true
 ---
 <ButtonDemo>
+	<Button primary extraLarge icon={<GearIcon />}>
+		Settings
+	</Button>
 	<Button primary small icon={<GearIcon />}>
 		Settings
 	</Button>

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -412,6 +412,7 @@ const components = [
 					`,
 					IconsContainer: styled.div`
 						color: #a8a8a8;
+
 						> * {
 							margin: 0 12px;
 						}

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -15,6 +15,11 @@ export const ButtonContents = styled.span`
 	grid-column-gap: 6px;
 	align-items: center;
 	justify-content: ${props => props.justifyContent || 'center'};
+
+	> svg {
+		height: 1em;
+		width: 1em;
+	}
 `;
 
 export const Anchor = styled.a`


### PR DESCRIPTION
Uses 1em height and width. Are our icons always guaranteed to be square?