### PR TITLE
Remove extraLarge, set explicit button heights

### DIFF
--- a/catalog/button/variations.md
+++ b/catalog/button/variations.md
@@ -17,18 +17,16 @@ showSource: true
 	<Button primary large>
 		Large
 	</Button>
-	<Button primary extraLarge>
-		Extra Large
-	</Button>
 </ButtonDemo>
 ```
 
 ### With Icon
+
 ```react
 showSource: true
 ---
 <ButtonDemo>
-	<Button primary extraLarge icon={<GearIcon />}>
+	<Button primary large icon={<GearIcon />}>
 		Settings
 	</Button>
 	<Button primary small icon={<GearIcon />}>
@@ -40,6 +38,7 @@ showSource: true
 ```
 
 ### With Attached Ref
+
 ```react
 showSource: true
 ---
@@ -54,6 +53,7 @@ showSource: true
 ```
 
 ### Supported style customizations
+
 Do not use the `style` prop to style this component (it will be ignored). Instead, if there is missing customization that you need for this component, ask to have it added. The `theme` prop can be used to control color variations while the `styleOverrides` prop can be used for other styles.
 
 ```react
@@ -72,14 +72,11 @@ showSource: true
 </ButtonDemo>
 ```
 
-
-* `small` -- used for apps with tight spacing, never for marketing pages.
-* `medium` -- this is the default size for web applications.
-* `large` -- this is the default scale for marketing web pages.
-* `extraLarge` -- extra large inputs and call-to-action buttons for marketing page use.
+- `small` -- this is the default size for web applications.
+- `medium` -- this is the default size for marketing web pages.
+- `large` -- for extra-special calls to action, used sparingly.
 
 ### Relative Emphasis
-
 
 ```react
 showSource: true
@@ -108,10 +105,10 @@ showSource: true
 </div>
 ```
 
-* `primary` -- for the most important or most common action for a user to take in a given context/scope. This button variant grabs the user's attention. In marketing pages, this style is for the "call to action" on a page.
-* `primaryOutline` -- for actions related to, or nearby the primary button in terms of visual hieararchy that are less common or less critical. Use this button when you want the user's casual attention.
-* `minor` -- for apps, not marketing pages. When there are a lot of common actions that are all of equal weight, consider using minor buttons.
-* `link` -- for situations where a hyperlink is indicated, but must be aligned with a row of buttons. Is very lightweight in terms of visual attention.
+- `primary` -- for the most important or most common action for a user to take in a given context/scope. This button variant grabs the user's attention. In marketing pages, this style is for the "call to action" on a page.
+- `primaryOutline` -- for actions related to, or nearby the primary button in terms of visual hieararchy that are less common or less critical. Use this button when you want the user's casual attention.
+- `minor` -- for apps, not marketing pages. When there are a lot of common actions that are all of equal weight, consider using minor buttons.
+- `link` -- for situations where a hyperlink is indicated, but must be aligned with a row of buttons. Is very lightweight in terms of visual attention.
 
 ## Disabled states
 
@@ -138,6 +135,7 @@ showSource: true
 ```
 
 ### Stretched buttons
+
 ```react
 showSource: true
 ---
@@ -167,8 +165,8 @@ showSource: true
 
 ## Button Text
 
-* Button text should be as concise as possible, but as long as necessary (for clarity).
-* Buttons are usually verbs (or short phrases that begin with a verb).
+- Button text should be as concise as possible, but as long as necessary (for clarity).
+- Buttons are usually verbs (or short phrases that begin with a verb).
 
 Buttons are generally interpreted as imperatives, with the computer as agent ("hey computer, do the thing"), the text of the thing to be done as a verb ("frob"), and a direct object to take the action on if needed ("frob widgets"). Thus a button that reads "frob widgets" will normally be interpreted by the user as them issuing the command: "Hey computer, frob the widgets!"
 
@@ -179,7 +177,6 @@ Some buttons are noun phrases, but there should always be an implied verb. For e
 ## Examples
 
 A product sales page enables three possible user actions: Buy the product, rent the product, or learn more about the product. Appropriate button styles and text would be: "Buy now" (primary), "Rent" (primaryOutline), and "Learn more" (minor). If they are all in a row, they would come in the order: "Learn more", "Rent", and "Buy now" on the right.
-
 
 ```react
 showSource: true

--- a/catalog/button/variations.md
+++ b/catalog/button/variations.md
@@ -174,6 +174,18 @@ There are some exceptions, such as "Buy Now" buttons, which are generally interp
 
 Some buttons are noun phrases, but there should always be an implied verb. For example: a "Settings" button that launches a settings dialog in the current context has an implied verb of "Show" or "Launch" (if the user is thinking of what the computer will do) or "Edit" or "Change" (if they're thinking of what they want to do).
 
+Button text should never wrap, and will be ellipsized if there isn't enough room for the button.
+
+```react
+showSource: true
+---
+<ButtonDemo style={{maxWidth: 250}}>
+	<Button primary small>
+		Really long button text for demonstration purposes
+	</Button>
+</ButtonDemo>
+```
+
 ## Examples
 
 A product sales page enables three possible user actions: Buy the product, rent the product, or learn more about the product. Appropriate button styles and text would be: "Buy now" (primary), "Rent" (primaryOutline), and "Learn more" (minor). If they are all in a row, they would come in the order: "Learn more", "Rent", and "Buy now" on the right.

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -44,11 +44,10 @@ import '../dist/text-input.css';
 import '../dist/ag-grid.css';
 
 const ButtonDemo = styled.div`
-	display: grid;
+	display: inline-grid;
 	grid-auto-flow: column;
 	align-items: center;
 	grid-column-gap: 12px;
-	width: min-content;
 `;
 
 const ButtonGrid = styled.div`

--- a/components/button/base-button.jsx
+++ b/components/button/base-button.jsx
@@ -31,14 +31,12 @@ export const BaseButton = forwardClassRef(
 			primary: PropTypes.bool,
 			/** Primary outline variation */
 			primaryOutline: PropTypes.bool,
-			/** Medium variation */
-			medium: PropTypes.bool,
 			/** Small variation */
 			small: PropTypes.bool,
+			/** Medium variation */
+			medium: PropTypes.bool,
 			/** Large variation */
 			large: PropTypes.bool,
-			/** Extra large variation */
-			extraLarge: PropTypes.bool,
 			/** Transparent with primary text variation */
 			primaryTransparent: PropTypes.bool,
 			/** Transparent with minor text variation */

--- a/components/button/base-button.jsx
+++ b/components/button/base-button.jsx
@@ -98,10 +98,10 @@ export const BaseButton = forwardClassRef(
 					onMouseUp={this.onMouseUp}
 					styleOverrides={componentStyleOverrides}
 				>
-					<Styled.ButtonContents justifyContent={justifyContent}>
+					<Styled.ButtonContentWrapper justifyContent={justifyContent}>
 						{icon}
-						{children}
-					</Styled.ButtonContents>
+						{children && <Styled.ButtonContents>{children}</Styled.ButtonContents>}
+					</Styled.ButtonContentWrapper>
 				</MappedStyledComponent>
 			);
 		}

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -178,15 +178,15 @@ export const variationMap = {
 		}
 `,
 	small: component => component.extend`
+		height: 32px;
 		padding: 7px ${props => (props.condensed ? '7px' : '9px')};
 `,
 	medium: component => component.extend`
+		height: 40px;
 		padding: 11px ${props => (props.condensed ? '11px' : '15px')};
 `,
 	large: component => component.extend`
-		padding: 14px ${props => (props.condensed ? '14px' : '20px')};
-`,
-	extraLarge: component => component.extend`
+		height: 56px;
 		padding: 15px ${props => (props.condensed ? '15px' : '23px')};
 		font-size: 24px;
 `,

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -9,7 +9,7 @@ const buttonColors = {
 	disabled: '#bedcf2',
 };
 
-export const ButtonContents = styled.span`
+export const ButtonContentWrapper = styled.div`
 	display: grid;
 	grid-auto-flow: column;
 	grid-column-gap: 6px;
@@ -20,6 +20,12 @@ export const ButtonContents = styled.span`
 		height: 1em;
 		width: 1em;
 	}
+`;
+
+export const ButtonContents = styled.div`
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 `;
 
 export const Anchor = styled.a`
@@ -54,7 +60,6 @@ export const Button = styled.button`
 	transition: all 0.25s ease 0s;
 	white-space: nowrap;
 	min-height: fit-content;
-	line-height: 1;
 	font-size: ${props => props.styleOverrides.fontSize || '16px'};
 	width: ${props => props.styleOverrides.width};
 	padding: ${props => props.styleOverrides.padding};
@@ -179,15 +184,15 @@ export const variationMap = {
 `,
 	small: component => component.extend`
 		height: 32px;
-		padding: 7px ${props => (props.condensed ? '7px' : '9px')};
+		padding: 0 ${props => (props.condensed ? '7px' : '9px')};
 `,
 	medium: component => component.extend`
 		height: 40px;
-		padding: 11px ${props => (props.condensed ? '11px' : '15px')};
+		padding: 0 ${props => (props.condensed ? '11px' : '15px')};
 `,
 	large: component => component.extend`
 		height: 56px;
-		padding: 15px ${props => (props.condensed ? '15px' : '23px')};
+		padding: 0 ${props => (props.condensed ? '15px' : '23px')};
 		font-size: 24px;
 `,
 };


### PR DESCRIPTION
The old "large" button size was not in the UI specs, and has now been
removed. The former "extraLarge" is now just "large".

There were no existing usages of "extraLarge" anywhere, and all the
existing usages of "large" have been migrated to be "medium".
All of those usages were in the Giving.Web project.

Firefox scales button border widths in unexpected ways:
https://bugzilla.mozilla.org/show_bug.cgi?id=1427391

> Yeah - this is intended behavior (though it can be a bit surprising).
> We snap border-widths to be exact multiples of device pixels, as noted
> in bug 477157 comment 7.

Since we expect the combination of line-height, padding, and border to
exactly equal certain pixel heights, setting that height explicitly is
not really a major change.

Discussion in FLCOM team chat:
https://beta.faithlife.com/messages/12492?threadId=504803