### PR TITLE
Restore reasonable z-index value for ModalBackdrop

### DIFF
--- a/components/modal-backdrop/component.jsx
+++ b/components/modal-backdrop/component.jsx
@@ -11,6 +11,10 @@ export class ModalBackdrop extends React.Component {
 		onClose: PropTypes.func.isRequired,
 		/** Contents of the modal */
 		children: PropTypes.node.isRequired,
+		/** Style overrides */
+		styleOverrides: PropTypes.shape({
+			zIndex: PropTypes.number,
+		}),
 	};
 
 	inPotentialCloseEvent = false;
@@ -38,7 +42,7 @@ export class ModalBackdrop extends React.Component {
 	};
 
 	render() {
-		const { children } = this.props;
+		const { children, styleOverrides } = this.props;
 
 		return (
 			<Styled.Backdrop
@@ -49,6 +53,7 @@ export class ModalBackdrop extends React.Component {
 				onMouseUp={this.handleBackdropCloseEventEnd}
 				onTouchStart={this.handleBackdropCloseEventStart}
 				onTouchEnd={this.handleBackdropCloseEventEnd}
+				styleOverrides={styleOverrides}
 			>
 				{children}
 			</Styled.Backdrop>

--- a/components/modal-backdrop/styled.jsx
+++ b/components/modal-backdrop/styled.jsx
@@ -11,5 +11,5 @@ export const Backdrop = styled.div`
 	justify-content: center;
 	align-items: center;
 	overflow: hidden;
-	z-index: 999999;
+	z-index: 1050;
 `;

--- a/components/modal-backdrop/styled.jsx
+++ b/components/modal-backdrop/styled.jsx
@@ -11,5 +11,5 @@ export const Backdrop = styled.div`
 	justify-content: center;
 	align-items: center;
 	overflow: hidden;
-	z-index: 1050;
+	z-index: ${props => props.styleOverrides.zIndex};
 `;

--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -25,9 +25,10 @@ export class Modal extends React.Component {
 		children: PropTypes.node.isRequired,
 		/** Customizable theme properties */
 		theme: PropTypes.object,
-		/** Style overrides */
+		/** Style overrides, the z-index is applied to the backdrop */
 		styleOverrides: PropTypes.shape({
 			bottomBorder: PropTypes.string,
+			zIndex: PropTypes.number,
 		}),
 		/** Values for rendering an FL standard footer */
 		footerProps: PropTypes.shape({
@@ -56,7 +57,9 @@ export class Modal extends React.Component {
 		theme: {
 			background: 'white',
 		},
-		styleOverrides: {},
+		styleOverrides: {
+			zIndex: 1050,
+		},
 	};
 
 	state = {
@@ -113,9 +116,13 @@ export class Modal extends React.Component {
 			(modalWidth < 220 ||
 				(modalWidth < 320 && footerProps && Object.keys(footerProps).length === 3));
 
+		const backdropStyleOverrides = {
+			zIndex: styleOverrides.zIndex,
+		};
+
 		return (
 			<ThemeProvider theme={{ ...theme, verticalButtons }}>
-				<ModalBackdrop onClose={onClose}>
+				<ModalBackdrop onClose={onClose} styleOverrides={backdropStyleOverrides}>
 					<Styled.Modal
 						innerRef={modal => {
 							this._modal = modal;


### PR DESCRIPTION
The z-index had previously been bumped from `1050` to `999999` in this commit:
https://github.com/Faithlife/styled-ui/commit/5123afde25b44beb856b5fec6534e7a0ca7a1510#diff-0765eae89daeaa485c09168b8b477a56L14