### PR TITLE
Set line-height on AnchorButtons

### DIFF
--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -33,6 +33,7 @@ export const Anchor = styled.a`
 	cursor: pointer;
 	transition: all 0.25s ease 0s;
 	white-space: nowrap;
+	line-height: 1;
 	font-size: ${props => props.styleOverrides.fontSize || '16px'};
 	width: ${props => props.styleOverrides.width};
 	padding: ${props => props.styleOverrides.padding};


### PR DESCRIPTION
I added `line-height: 1` to `Button` components but failed to add it to `AnchorButton` components.