### PR TITLE
Fix checkbox text alignment when text wraps

### DIFF
--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -21,6 +21,7 @@ export const CheckboxContainer = styled.button`
 	min-width: 16px;
 	min-height: 16px;
 	background: transparent;
+	text-align: unset;
 
 	&:active {
 		color: buttontext;


### PR DESCRIPTION
The checkbox component inherits its text-alignment value (center) from the agent style for buttons, a value that isn't apparent until the label is long enough to wrap:

![image](https://user-images.githubusercontent.com/2214238/51701777-0d15db80-1fc7-11e9-820b-cb6d4934ba1c.png)

This changes allows the checkbox component to inherit its alignment value from parent elements.