### PR TITLE
Hide slider labels after touch events.

### DIFF
--- a/components/slider/component.jsx
+++ b/components/slider/component.jsx
@@ -111,6 +111,7 @@ export class Slider extends PureComponent {
 		}
 
 		this.setState({ isSliding: false });
+		this.handleTogglePopover(false, 250);
 	};
 
 	handleMouseDown = event => {


### PR DESCRIPTION
We already correctly hide labels after mouse and keyboard input events, but I missed touch input.