### PR TITLE
Prevent clicking on descendants of Buttons

### DIFF
--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -14,6 +14,7 @@ export const ButtonContentWrapper = styled.div`
 	grid-auto-flow: column;
 	grid-column-gap: 6px;
 	align-items: center;
+	pointer-events: none;
 	justify-content: ${props => props.justifyContent || 'center'};
 
 	> svg {


### PR DESCRIPTION
There is no good reason for a _child_ of a button component to be clickable, or for the click event to take on the `value` attribute of that child element. I'm suggesting that we add `pointer-events: none;` to the ButtonContentWrapper to address this situation.

Preview link demonstrating the problem:
https://deploy-preview-134--faithlife-styled-ui.netlify.com/#/button/variations?a=the-problem