### PR TITLE
Update large input size.

### DIFF
--- a/components/input/styled.jsx
+++ b/components/input/styled.jsx
@@ -42,7 +42,7 @@ export const variationMap = {
 	`,
 	large: component => styled(component)`
 		padding: 16px;
-		height: 46px;
-		${fonts.ui16};
+		height: 56px;
+		${fonts.ui18};
 	`,
 };


### PR DESCRIPTION
Spec: https://app.zeplin.io/project/58a23c2d4597afb248c13a43/screen/59ee876ea8d2f3caa6ff296d

We're using the Medium/Large/Super sizes from that spec as Small/Medium/Large to match the Small/Medium/Large buttons that we have live:
https://faithlife.github.io/styled-ui/#/button/variations

Relates to issue #59 

This large size is only used by one consumer, and they've already overridden the relevant styles.