### PR TITLE
Add click handler to hide tooltip.

### DIFF
--- a/components/popover/tooltip.jsx
+++ b/components/popover/tooltip.jsx
@@ -17,7 +17,12 @@ export class Tooltip extends Component {
 		tooltipIsOpen: false,
 	};
 
+	componentDidMount() {
+		window.addEventListener('click', this.handleClick);
+	}
+
 	componentWillUnmount() {
+		window.removeEventListener('click', this.handleClick);
 		this.handleMouseLeave.cancel();
 	}
 
@@ -32,6 +37,14 @@ export class Tooltip extends Component {
 	handleMouseEnter = () => {
 		this.handleMouseLeave.cancel();
 		this.setState({ tooltipIsOpen: true });
+	};
+
+	handleClick = () => {
+		if (!this.state.tooltipIsOpen) {
+			return;
+		}
+
+		this.setState({ tooltipIsOpen: false });
 	};
 
 	render() {

--- a/components/text-input-v2/inferred-base.jsx
+++ b/components/text-input-v2/inferred-base.jsx
@@ -60,6 +60,14 @@ export class InferredBase extends Component {
 		confidenceSource: 'Heuristic Algorithm',
 	};
 
+	componentDidMount() {
+		window.addEventListener('click', this.handleClick);
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener('click', this.handleClick);
+	}
+
 	componentWillReceiveProps(props) {
 		if (props.confidence !== this.props.confidence) {
 			this.setState({ isPopoverOpen: false });
@@ -67,6 +75,14 @@ export class InferredBase extends Component {
 	}
 
 	state = { isPopoverOpen: false };
+
+	handleClick = () => {
+		if (!this.state.isPopoverOpen) {
+			return;
+		}
+
+		this.setState({ isPopoverOpen: false });
+	};
 
 	render() {
 		const { confidence, confidenceSource, onConfirm } = this.props;


### PR DESCRIPTION
The tooltip doesn't *always* vanish when the mouse leaves the element. I thought it might be because of the debounce func, but rather than that I figured it would be more effective to just hide the tooltip on document click.