### PR TITLE
Display deprecation warnings to the consumer.

### DIFF
--- a/components/text-input/typeahead.jsx
+++ b/components/text-input/typeahead.jsx
@@ -73,65 +73,39 @@ const RelativeContainer = styled.div`
 	position: relative;
 `;
 
-export class AsyncTypeahead extends React.Component {
-	static propTypes = { inferred: PropTypes.bool };
+export const Typeahead = ({ inferred, ...props }) => (
+	<BootstrapContainer>
+		<RelativeContainer>
+			<StyledTypeahead {...props} />
+			{!inferred && (
+				<IndicatorContainer>
+					<SolidTriangleIcon />
+				</IndicatorContainer>
+			)}
+		</RelativeContainer>
+	</BootstrapContainer>
+);
 
-	componentDidMount() {
-		if (process.env.NODE_ENV !== 'production') {
-			console.warn(
-				'Warning: You are using a deprecated `AsyncTypeahead` element. \n',
-				'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
-				'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
-			);
-		}
-	}
+export const AsyncTypeahead = ({ inferred, ...props }) => (
+	<BootstrapContainer>
+		<RelativeContainer>
+			<StyledAsyncTypeahead {...props} />
+			{!inferred && (
+				<IndicatorContainer>
+					<SolidTriangleIcon />
+				</IndicatorContainer>
+			)}
+		</RelativeContainer>
+	</BootstrapContainer>
+);
 
-	render() {
-		const { inferred, ...otherProps } = this.props;
-		return (
-			<BootstrapContainer>
-				<RelativeContainer>
-					<StyledAsyncTypeahead {...otherProps} />
-					{!inferred && (
-						<IndicatorContainer>
-							<SolidTriangleIcon />
-						</IndicatorContainer>
-					)}
-				</RelativeContainer>
-			</BootstrapContainer>
-		);
-	}
-}
+Typeahead.propTypes = {
+	inferred: PropTypes.bool,
+};
 
-export class Typeahead extends React.Component {
-	static propTypes = { inferred: PropTypes.bool };
-
-	componentDidMount() {
-		if (process.env.NODE_ENV !== 'production') {
-			console.warn(
-				'Warning: You are using a deprecated `Typeahead` element. \n',
-				'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
-				'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
-			);
-		}
-	}
-
-	render() {
-		const { inferred, ...otherProps } = this.props;
-		return (
-			<BootstrapContainer>
-				<RelativeContainer>
-					<StyledTypeahead {...otherProps} />
-					{!inferred && (
-						<IndicatorContainer>
-							<SolidTriangleIcon />
-						</IndicatorContainer>
-					)}
-				</RelativeContainer>
-			</BootstrapContainer>
-		);
-	}
-}
+AsyncTypeahead.propTypes = {
+	inferred: PropTypes.bool,
+};
 
 export const Token = _Token;
 export const Menu = _Menu;

--- a/components/text-input/typeahead.jsx
+++ b/components/text-input/typeahead.jsx
@@ -73,39 +73,63 @@ const RelativeContainer = styled.div`
 	position: relative;
 `;
 
-export const AsyncTypeahead = ({ inferred, ...props }) => (
-	<BootstrapContainer>
-		<RelativeContainer>
-			<StyledAsyncTypeahead {...props} />
-			{!inferred && (
-				<IndicatorContainer>
-					<SolidTriangleIcon />
-				</IndicatorContainer>
-			)}
-		</RelativeContainer>
-	</BootstrapContainer>
-);
+export class AsyncTypeahead extends React.Component {
+	static propTypes = { inferred: PropTypes.bool };
 
-export const Typeahead = ({ inferred, ...props }) => (
-	<BootstrapContainer>
-		<RelativeContainer>
-			<StyledTypeahead {...props} />
-			{!inferred && (
-				<IndicatorContainer>
-					<SolidTriangleIcon />
-				</IndicatorContainer>
-			)}
-		</RelativeContainer>
-	</BootstrapContainer>
-);
+	componentDidMount() {
+		console.warn(
+			'Warning: You are using a deprecated `AsyncTypeahead` element. \n',
+			'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
+			'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
+		);
+	}
 
-Typeahead.propTypes = {
-	inferred: PropTypes.bool,
-};
+	render() {
+		const { inferred, ...otherProps } = this.props;
+		return (
+			<BootstrapContainer>
+				<RelativeContainer>
+					<StyledAsyncTypeahead {...otherProps} />
+					{!inferred && (
+						<IndicatorContainer>
+							<SolidTriangleIcon />
+						</IndicatorContainer>
+					)}
+				</RelativeContainer>
+			</BootstrapContainer>
+		);
+	}
+}
 
-AsyncTypeahead.propTypes = {
-	inferred: PropTypes.bool,
-};
+export class Typeahead extends React.Component {
+	static propTypes = { inferred: PropTypes.bool };
+
+	componentDidMount() {
+		if (process.env.NODE_ENV !== 'production') {
+			console.warn(
+				'Warning: You are using a deprecated `Typeahead` element. \n',
+				'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
+				'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
+			);
+		}
+	}
+
+	render() {
+		const { inferred, ...otherProps } = this.props;
+		return (
+			<BootstrapContainer>
+				<RelativeContainer>
+					<StyledTypeahead {...otherProps} />
+					{!inferred && (
+						<IndicatorContainer>
+							<SolidTriangleIcon />
+						</IndicatorContainer>
+					)}
+				</RelativeContainer>
+			</BootstrapContainer>
+		);
+	}
+}
 
 export const Token = _Token;
 export const Menu = _Menu;

--- a/components/text-input/typeahead.jsx
+++ b/components/text-input/typeahead.jsx
@@ -77,11 +77,13 @@ export class AsyncTypeahead extends React.Component {
 	static propTypes = { inferred: PropTypes.bool };
 
 	componentDidMount() {
-		console.warn(
-			'Warning: You are using a deprecated `AsyncTypeahead` element. \n',
-			'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
-			'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
-		);
+		if (process.env.NODE_ENV !== 'production') {
+			console.warn(
+				'Warning: You are using a deprecated `AsyncTypeahead` element. \n',
+				'You can find the deprecation documentation here: https://faithlife.github.io/styled-ui/#/text-input/typeahead \n',
+				'And you can find the documentation for the element that has replaced this one here: https://faithlife.github.io/styled-ui/#/text-input/select',
+			);
+		}
 	}
 
 	render() {

--- a/components/utils/bootstrap-container.jsx
+++ b/components/utils/bootstrap-container.jsx
@@ -3,23 +3,39 @@ import PropTypes from 'prop-types';
 
 const { Provider, Consumer } = React.createContext({});
 
-export const BootstrapContainer = ({ children, styles }) => (
-	<Consumer>
-		{value =>
-			value.inCssResetScope ? (
-				children
-			) : (
-				<Provider value={{ inCssResetScope: true }}>
-					<BootstrapContainer styles={styles}>
-						<div className="fl-b" style={styles}>
-							{children}
-						</div>
-					</BootstrapContainer>
-				</Provider>
-			)
+export class BootstrapContainer extends React.Component {
+	static propTypes = { children: PropTypes.node.isRequired, styles: PropTypes.object };
+
+	componentDidMount() {
+		if (process.env.NODE_ENV !== 'production') {
+			console.warn(
+				'Warning: You are using a deprecated Bootstrap element. \n',
+				'Styled-UI has replaced all Bootstrap elements: https://faithlife.github.io/styled-ui/#/ \n',
+			);
 		}
-	</Consumer>
-);
+	}
+
+	render() {
+		const { children, styles } = this.props;
+		return (
+			<Consumer>
+				{value =>
+					value.inCssResetScope ? (
+						children
+					) : (
+						<Provider value={{ inCssResetScope: true }}>
+							<BootstrapContainer styles={styles}>
+								<div className="fl-b" style={styles}>
+									{children}
+								</div>
+							</BootstrapContainer>
+						</Provider>
+					)
+				}
+			</Consumer>
+		);
+	}
+}
 
 export function wrapBootstrap(Component, inline) {
 	const styles = inline ? { display: 'inline-block' } : {};
@@ -29,8 +45,3 @@ export function wrapBootstrap(Component, inline) {
 		</BootstrapContainer>
 	);
 }
-
-BootstrapContainer.propTypes = {
-	children: PropTypes.node.isRequired,
-	styles: PropTypes.object,
-};

--- a/components/utils/bootstrap-container.jsx
+++ b/components/utils/bootstrap-container.jsx
@@ -1,41 +1,40 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 const { Provider, Consumer } = React.createContext({});
 
-export class BootstrapContainer extends React.Component {
-	static propTypes = { children: PropTypes.node.isRequired, styles: PropTypes.object };
-
-	componentDidMount() {
+export const BootstrapContainer = ({ children, styles }) => {
+	useEffect(() => {
 		if (process.env.NODE_ENV !== 'production') {
 			console.warn(
 				'Warning: You are using a deprecated Bootstrap element. \n',
 				'Styled-UI has replaced all Bootstrap elements: https://faithlife.github.io/styled-ui/#/ \n',
 			);
 		}
-	}
+	}, []);
+	return (
+		<Consumer>
+			{value =>
+				value.inCssResetScope ? (
+					children
+				) : (
+					<Provider value={{ inCssResetScope: true }}>
+						<BootstrapContainer styles={styles}>
+							<div className="fl-b" style={styles}>
+								{children}
+							</div>
+						</BootstrapContainer>
+					</Provider>
+				)
+			}
+		</Consumer>
+	);
+};
 
-	render() {
-		const { children, styles } = this.props;
-		return (
-			<Consumer>
-				{value =>
-					value.inCssResetScope ? (
-						children
-					) : (
-						<Provider value={{ inCssResetScope: true }}>
-							<BootstrapContainer styles={styles}>
-								<div className="fl-b" style={styles}>
-									{children}
-								</div>
-							</BootstrapContainer>
-						</Provider>
-					)
-				}
-			</Consumer>
-		);
-	}
-}
+BootstrapContainer.propTypes = {
+	children: PropTypes.node.isRequired,
+	styles: PropTypes.object,
+};
 
 export function wrapBootstrap(Component, inline) {
 	const styles = inline ? { display: 'inline-block' } : {};


### PR DESCRIPTION
The only deprecated element I could find was text-input v1 which was built using Typeahead and AsyncTypeahead, so I included those two elements. If I'm mistaken on how text-input v1 works or if I missed some deprecated elements let me know.