### PR TITLE
Use "body" as the default container for popovers/modals

### DIFF
--- a/catalog/grid/member-directory.jsx
+++ b/catalog/grid/member-directory.jsx
@@ -47,7 +47,7 @@ class KebabCell extends Component {
 							<KebabVertical />
 						</IconButton>
 					</PopoverReference>
-					<Popover container="body" isOpen={this.state.dropDownOpen} placement="top">
+					<Popover isOpen={this.state.dropDownOpen} placement="top">
 						Some sample content
 					</Popover>
 				</PopoverManager>

--- a/catalog/modal/variations.md
+++ b/catalog/modal/variations.md
@@ -8,7 +8,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -71,7 +70,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -103,7 +101,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -136,7 +133,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -169,7 +165,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -209,7 +204,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Location"
 		subtitle="Help us locate you"
@@ -238,7 +232,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Lots of content"
 	>
@@ -259,7 +252,6 @@ state: { modal: false, value: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Modal with no title border"
 		styleOverrides={{ bottomBorder: 'none' }}

--- a/catalog/popover/variations.md
+++ b/catalog/popover/variations.md
@@ -110,13 +110,13 @@ state: { isOpen: false }
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top">I'm inline</Popover>
+		<Popover isOpen={state.isOpen} placement="top" container="inline">I'm inline</Popover>
 	</PopoverManager>
 	<PopoverManager>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" container="body">I'm thinking with portals!</Popover>
+		<Popover isOpen={state.isOpen} placement="top">I'm thinking with portals!</Popover>
 	</PopoverManager>
 </PopoverOverflowDemo>
 ```
@@ -134,13 +134,13 @@ state: { isOpen: false }
 		<PopoverReference>
 			<Button primary disableAutoBlur medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top">Click or tab to make me go away</Popover>
+		<Popover isOpen={state.isOpen} placement="top" container="inline">Click or tab to make me go away</Popover>
 	</PopoverManager>
 	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium disableAutoBlur onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" container="body">I'm thinking with portals!</Popover>
+		<Popover isOpen={state.isOpen} placement="top">I'm thinking with portals!</Popover>
 	</PopoverManager>
 </PopoverDemo>
 ```

--- a/catalog/text-input/select.md
+++ b/catalog/text-input/select.md
@@ -45,7 +45,6 @@ state: { modal: false, value: '', selection: '' }
 	<Button primary medium onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
 	<Modal
 		isOpen={state.modal}
-		container="body"
 		onClose={() => setState({ modal: false })}
 		title="Test"
 		footerProps={{

--- a/components/group-selector/large/component.jsx
+++ b/components/group-selector/large/component.jsx
@@ -248,7 +248,6 @@ export class LargeGroupSelector extends React.Component {
 			<Styled.LargeGroupSelector>
 				{this.props.showInPlace && mainView}
 				<SimpleModal
-					container="body"
 					isOpen={
 						(!this.props.showInPlace && this.props.isOpen) ||
 						(this.props.showInPlace && secondaryModalOpen) ||

--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -73,15 +73,14 @@ export class Modal extends React.Component {
 		this.setState({ canUseDom: true }); // eslint-disable-line
 
 		const { container } = this.props;
-		if (container) {
-			if (typeof container === 'string') {
-				// must be an id or body
-				this.targetContainer =
-					container === 'body' ? document.body : document.getElementById(container);
-			} else {
-				// must be a ref
-				this.targetContainer = typeof container === 'object' ? container.current : container();
-			}
+		if (container === undefined || container === 'body') {
+			this.targetContainer = document.body;
+		} else if (typeof container === 'string') {
+			// must be an id or body
+			this.targetContainer = document.getElementById(container);
+		} else {
+			// must be a ref
+			this.targetContainer = typeof container === 'object' ? container.current : container();
 		}
 	}
 

--- a/components/popover/popover-base.jsx
+++ b/components/popover/popover-base.jsx
@@ -85,15 +85,14 @@ export class PopoverBase extends Component {
 
 	componentDidMount() {
 		const { container } = this.props;
-		if (container) {
-			if (typeof container === 'string') {
-				// must be an id or body
-				this.targetContainer =
-					container === 'body' ? document.body : document.getElementById(container);
-			} else {
-				// must be a ref
-				this.targetContainer = typeof container === 'object' ? container.current : container();
-			}
+		if (container === undefined || container === 'body') {
+			this.targetContainer = document.body;
+		} else if (typeof container === 'string') {
+			// must be an id or body
+			this.targetContainer = document.getElementById(container);
+		} else {
+			// must be a ref
+			this.targetContainer = typeof container === 'object' ? container.current : container();
 		}
 	}
 

--- a/components/popover/tooltip.jsx
+++ b/components/popover/tooltip.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import { Popover } from './component';
-import { PopoverManager, PopoverReference } from './popper-helpers';
+import { PopoverManager, PopoverReference } from '../popover';
 
 /** Simple tooltip that uses popovers internally. Does not support custom positioning. */
 export class Tooltip extends Component {

--- a/components/share-dialog/component.jsx
+++ b/components/share-dialog/component.jsx
@@ -66,7 +66,7 @@ export class ShareDialog extends React.Component {
 		);
 
 		return (
-			<Modal withoutFooter isOpen={isOpen} onClose={onClose} title={modalTitle} container="body">
+			<Modal withoutFooter isOpen={isOpen} onClose={onClose} title={modalTitle}>
 				{onDesktop ? desktopModal : mobileModal}
 			</Modal>
 		);

--- a/components/slider/component.jsx
+++ b/components/slider/component.jsx
@@ -296,7 +296,6 @@ export class Slider extends PureComponent {
 										labels[index] !== ''
 									}
 									placement={'top'}
-									container="body"
 									modifiers={{ offset: { offset: '0, 33' } }}
 								>
 									{`${labels[index]}`}


### PR DESCRIPTION
Previously, the default was inline which caused clipping issues when used in containers with overflow:hidden. Changing the default to 'body' allows most modals/popovers to work as expected with the option of containing the popup with the container prop.