### PR TITLE
Tell consumers that focus handling on Popovers should always be used

### DIFF
--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -7,7 +7,7 @@ state: { selectedDate: null }
 <DatePickerDemo>
 <div>
 <span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 		</PopoverReference>
@@ -33,7 +33,7 @@ state: { selectedDateRange: null }
 <DatePickerDemo>
 <div>
 	<span>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</span>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Select Dates</Button>
 		</PopoverReference>
@@ -60,7 +60,7 @@ state: { selectedDateRange: null }
 <DatePickerDemo>
 <div>
 	<span style={{ marginRight: '8px' }}>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</span>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Select Dates</Button>
 		</PopoverReference>

--- a/catalog/popover/variations.md
+++ b/catalog/popover/variations.md
@@ -1,11 +1,13 @@
 ## Popover
 
+onFocusAway should always be used according to the spec.
+
 ```react
 showSource: true
 state: { isOpen: false }
 ---
 <PopoverDemo>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
@@ -21,7 +23,7 @@ showSource: true
 state: { isOpen: false }
 ---
 <PopoverDemo>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
@@ -37,25 +39,25 @@ showSource: true
 state: { isOpen: false }
 ---
 <PopoverDemo>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top">Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="bottom">Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager  onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="left">Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
@@ -71,25 +73,25 @@ showSource: true
 state: { isOpen: false }
 ---
 <PopoverDemo>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top" theme={{ backgroundColor: '#ebf7ff' }}>Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover with zIndex!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top" styleOverrides={{ padding: '18px', hideShadow: true, width: '200px', border: 'black solid 1px', zIndex: 10 }}>Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top" hideArrow>Hello!</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover w/ a delay!</Button>
 		</PopoverReference>
@@ -106,43 +108,19 @@ state: { isOpen: false }
 ---
 // overflow: hidden
 <PopoverOverflowDemo>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top">I'm inline</Popover>
 	</PopoverManager>
-	<PopoverManager>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button primary medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="top" container="body">I'm thinking with portals!</Popover>
 	</PopoverManager>
 </PopoverOverflowDemo>
-```
-
-## With focus handling
-
-Works with container prop as well.
-
-```react
-showSource: true
-state: { isOpen: false }
----
-<PopoverDemo>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
-		<PopoverReference>
-			<Button primary disableAutoBlur medium onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
-		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top">Click or tab to make me go away</Popover>
-	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
-		<PopoverReference>
-			<Button primary medium disableAutoBlur onClick={() => setState({ isOpen: !state.isOpen })}>Show a Popover!</Button>
-		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" container="body">I'm thinking with portals!</Popover>
-	</PopoverManager>
-</PopoverDemo>
 ```
 
 ## Tooltip

--- a/components/popover/popover-manager.jsx
+++ b/components/popover/popover-manager.jsx
@@ -22,5 +22,6 @@ export function PopoverManager({ children, onFocusAway }) {
 
 PopoverManager.propTypes = {
 	children: PropTypes.node.isRequired,
+	/** Per spec, this should always be used to support closing on click away. */
 	onFocusAway: PropTypes.func,
 };


### PR DESCRIPTION
Amber says that popovers should have focus handling as a default. To avoid a breaking change and because the `onFocusAway` prop is best defined by the consumer, Korbin and I have decided that adding focus handling to all the demos and heavily suggesting it in the docs would be best.