### PR TITLE
Check for null when mapping children.

### DIFF
--- a/components/accordion/accordion.jsx
+++ b/components/accordion/accordion.jsx
@@ -49,7 +49,9 @@ export function Accordion({ children, expandedSections, hideArrows, onExpansion,
 	return (
 		<Styled.Accordion onKeyDown={handleKeyboardNav}>
 			<AccordionContextProvider value={context}>
-				{React.Children.map(children, (child, index) => React.cloneElement(child, { index }))}
+				{React.Children.map(children, (child, index) =>
+					React.isValidElement(child) ? React.cloneElement(child, { index }) : null,
+				)}
 			</AccordionContextProvider>
 		</Styled.Accordion>
 	);

--- a/components/dropdown/dropdown-menu-core.jsx
+++ b/components/dropdown/dropdown-menu-core.jsx
@@ -51,7 +51,9 @@ export function DropdownMenuCore({ children, popoverProps, ariaProps }) {
 				{...popoverProps}
 			>
 				<Styled.DropdownMenuContent onKeyDown={handleKeyboardNav}>
-					{React.Children.map(children, (child, index) => React.cloneElement(child, { index }))}
+					{React.Children.map(children, (child, index) =>
+						React.isValidElement(child) ? React.cloneElement(child, { index }) : null,
+					)}
 				</Styled.DropdownMenuContent>
 			</Popover>
 		</div>

--- a/components/dropdown/dropdown-utils.js
+++ b/components/dropdown/dropdown-utils.js
@@ -51,7 +51,7 @@ export function useKeyboardActivate(onToggleMenu, setSelectedItem) {
 
 export function getFocusableChildrenList(children) {
 	return React.Children.map(children, (child, index) =>
-		!child.type.isFocusableMenuChild ? null : index,
+		!child || !child.type.isFocusableMenuChild ? null : index,
 	).filter(index => index !== null);
 }
 

--- a/components/tabs/tab-helpers.jsx
+++ b/components/tabs/tab-helpers.jsx
@@ -12,13 +12,15 @@ export function TabList({ children }) {
 	return (
 		<Styled.TabList onKeyDown={handleKeyboardNav}>
 			{React.Children.map(children, (child, index) =>
-				React.cloneElement(child, {
-					selected: selectedTabIndex === index,
-					onSelectTab,
-					index,
-					theme,
-					panelId: panelIdsMap[index],
-				}),
+				React.isValidElement(child)
+					? React.cloneElement(child, {
+							selected: selectedTabIndex === index,
+							onSelectTab,
+							index,
+							theme,
+							panelId: panelIdsMap[index],
+					  })
+					: null,
 			)}
 		</Styled.TabList>
 	);
@@ -33,12 +35,14 @@ export function TabPanels({ children }) {
 	return (
 		<div>
 			{React.Children.map(children, (child, index) =>
-				React.cloneElement(child, {
-					registerPanelId,
-					unRegisterPanelId,
-					index,
-					selected: selectedTabIndex === index,
-				}),
+				React.isValidElement(child)
+					? React.cloneElement(child, {
+							registerPanelId,
+							unRegisterPanelId,
+							index,
+							selected: selectedTabIndex === index,
+					  })
+					: null,
 			)}
 		</div>
 	);

--- a/components/tabs/tab-utils.js
+++ b/components/tabs/tab-utils.js
@@ -29,7 +29,7 @@ export function useKeyboardNav(selectedIndex, onSelectTab, children) {
 	const handleKeyboardNav = useCallback(
 		event => {
 			const enabledTabIndexes = React.Children.map(currentChildren.current, (child, index) =>
-				child.props.disabled ? null : index,
+				!child || child.props.disabled ? null : index,
 			).filter(index => index !== null);
 			const currentEnabledIndex = enabledTabIndexes.indexOf(selectedIndex);
 


### PR DESCRIPTION
Allows conditionally rendering accordion items and tabs, as well as adding the checks in other places.