### PR TITLE
Fix misc errors and warnings.

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -801,7 +801,7 @@ const components = [
 					Label: styled.span`
 						margin-right: 8px;
 					`,
-					DownArrow: styled.img.attrs({ src: DownArrow })``,
+					DownArrow: styled.img.attrs(props => ({ src: DownArrow }))``,
 				},
 			},
 			{

--- a/catalog/listbox/variations.md
+++ b/catalog/listbox/variations.md
@@ -17,8 +17,8 @@ state: { isOpen: false, selected: 0 }
 	>
 		<ListboxToggle primary medium icon={<DownArrow />} styleOverrides={{width: '100px'}}>{browserList[state.selected]}</ListboxToggle>
 		<ListboxMenu>
-			{browserList.map((name, index) => <ListItem id={index}>{name}</ListItem>)}
-			<ListItem id="ie" disabled>Internet Explorer</ListItem>
+			{browserList.map((name, index) => <ListItem id={index} key={index}>{name}</ListItem>)}
+			<ListItem id="ie" key="ie" disabled>Internet Explorer</ListItem>
 		</ListboxMenu>
 	</Listbox>
 </ListboxDemo>

--- a/components/accordion/styled-header.jsx
+++ b/components/accordion/styled-header.jsx
@@ -11,10 +11,10 @@ export const HeadingWrapper = styled.div`
 		renderCustomIndicator ? '[title] 1fr [indicator] min-content' : '[title] auto [space] 0'};
 `;
 
-export const Heading = styled.header.attrs({
+export const Heading = styled.header.attrs(props => ({
 	role: 'heading',
-	'aria-level': ({ ariaLevel }) => ariaLevel,
-})`
+	'aria-level': props.ariaLevel,
+}))`
 	${resetStyles};
 
 	grid-column: 1 / span 2;
@@ -23,12 +23,12 @@ export const Heading = styled.header.attrs({
 	width: 100%;
 `;
 
-export const Button = styled.button.attrs({
+export const Button = styled.button.attrs(props => ({
 	role: 'button',
-	'aria-expanded': ({ isExpanded }) => isExpanded,
-	'aria-controls': ({ panelId }) => `accordion-panel-${panelId}`,
-	id: ({ headerId }) => `accordion-header-${headerId}`,
-})`
+	'aria-expanded': props.isExpanded,
+	'aria-controls': `accordion-panel-${props.panelId}`,
+	id: `accordion-header-${props.headerId}`,
+}))`
 	${resetStyles};
 
 	padding: 0;

--- a/components/accordion/styled-panel.jsx
+++ b/components/accordion/styled-panel.jsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import { resetStyles } from '../utils';
 
-export const Panel = styled.div.attrs({
+export const Panel = styled.div.attrs(props => ({
 	role: 'region',
-	'aria-labelledby': ({ headerId }) => `accordion-header-${headerId}`,
-	id: ({ panelId }) => `accordion-panel-${panelId}`,
-})`
+	'aria-labelledby': `accordion-header-${props.headerId}`,
+	id: `accordion-panel-${props.panelId}`,
+}))`
 	${resetStyles};
 
 	grid-area: panel;

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -9,7 +9,7 @@ const buttonColors = {
 	disabled: '#bedcf2',
 };
 
-export const ButtonContentWrapper = styled.div.attrs({ tabIndex: '-1' })`
+export const ButtonContentWrapper = styled.div.attrs(_ => ({ tabIndex: '-1' }))`
 	display: grid;
 	grid-auto-flow: column;
 	grid-column-gap: 6px;

--- a/components/dropdown/styled.jsx
+++ b/components/dropdown/styled.jsx
@@ -10,12 +10,12 @@ export const DropdownMenuContent = styled.div`
 	flex-direction: column;
 `;
 
-export const MenuItem = styled.button.attrs({
+export const MenuItem = styled.button.attrs(props => ({
 	// Menu items should not be in the tab order. They are only reachable by the arrow keys
 	tabIndex: '-1',
-	role: ({ role }) => role || 'menuitem',
+	role: props.role || 'menuitem',
 	'aria-disabled': ({ isDisabled }) => isDisabled,
-})`
+}))`
 	${resetStyles};
 	outline: none;
 	border: none;
@@ -36,7 +36,7 @@ export const MenuItem = styled.button.attrs({
 	}
 `;
 
-export const MenuItemContent = styled.span.attrs({ tabIndex: '-1' })`
+export const MenuItemContent = styled.span.attrs(_ => ({ tabIndex: '-1' }))`
 	${({ isDisabled }) => isDisabled && `color: ${colors.gray22}`};
 
 	padding: ${({ styleOverrides }) => styleOverrides.padding || thickness.eight};
@@ -59,10 +59,10 @@ export const MenuItemContent = styled.span.attrs({ tabIndex: '-1' })`
 	}
 `;
 
-export const MenuSeparator = styled.hr.attrs({
+export const MenuSeparator = styled.hr.attrs(_ => ({
 	role: 'separator',
 	'aria-orientation': 'horizontal',
-})`
+}))`
 	border: 0;
 	border-top: 1px solid ${colors.gray14};
 	width: 100%;

--- a/components/parameter-sentence/styled.jsx
+++ b/components/parameter-sentence/styled.jsx
@@ -51,7 +51,7 @@ export const Button = styled.button`
 	}
 `;
 
-export const ButtonContent = styled.div.attrs({ tabIndex: '-1' })`
+export const ButtonContent = styled.div.attrs(_ => ({ tabIndex: '-1' }))`
 	${selectStyling};
 `;
 
@@ -77,10 +77,10 @@ export const InputContainer = styled.div`
 	}
 `;
 
-export const ParameterSentence = styled.form.attrs({
-	role: props => (props.isSearchForm ? 'search' : 'form'),
-	'aria-labelledby': ({ labelledBy }) => labelledBy,
-})`
+export const ParameterSentence = styled.form.attrs(props => ({
+	role: props.isSearchForm ? 'search' : 'form',
+	'aria-labelledby': props.labelledBy,
+}))`
 	/* stylelint-disable no-empty-block https://github.com/stylelint/stylelint/issues/3494 */
 `;
 

--- a/components/popover/styled.jsx
+++ b/components/popover/styled.jsx
@@ -129,7 +129,7 @@ export const ReferenceContainer = styled.div`
 	display: inline-block;
 `;
 
-export const FocusCatcher = styled.div.attrs({ tabIndex: '-1' })`
+export const FocusCatcher = styled.div.attrs(_ => ({ tabIndex: '-1' }))`
 	display: inline-block;
 
 	&:focus {

--- a/components/tabs/styled.jsx
+++ b/components/tabs/styled.jsx
@@ -39,13 +39,13 @@ const selectedTab = css`
 	border-left: 1px solid ${colors.gray14};
 `;
 
-export const Tab = styled.button.attrs({
+export const Tab = styled.button.attrs(props => ({
 	role: 'tab',
-	'aria-selected': ({ selected }) => selected,
-	'aria-controls': ({ panelId }) => `panel:${panelId}`,
-	'aria-disabled': ({ disabled }) => disabled,
-	tabIndex: ({ selected }) => (selected ? '0' : '-1'),
-})`
+	'aria-selected': props.selected,
+	'aria-controls': `panel:${props.panelId}`,
+	'aria-disabled': props.disabled,
+	tabIndex: props.selected ? '0' : '-1',
+}))`
 	${resetStyles};
 
 	box-shadow: none;
@@ -66,7 +66,7 @@ export const Tab = styled.button.attrs({
 	}
 `;
 
-export const TabContent = styled.span.attrs({ tabIndex: -1 })`
+export const TabContent = styled.span.attrs(_ => ({ tabIndex: -1 }))`
 	border-radius: ${borderRadius};
 	cursor: pointer;
 	white-space: nowrap;
@@ -86,7 +86,7 @@ export const TabContent = styled.span.attrs({ tabIndex: -1 })`
 	${({ selected }) => selected && selectedTab};
 `;
 
-export const TabList = styled.div.attrs({ role: 'tablist' })`
+export const TabList = styled.div.attrs(_ => ({ role: 'tablist' }))`
 	border-bottom: 1px solid ${colors.gray14};
 	display: flex;
 	flex-direction: row;
@@ -96,11 +96,11 @@ export const TabList = styled.div.attrs({ role: 'tablist' })`
 	}
 `;
 
-export const TabPanel = styled.div.attrs({
+export const TabPanel = styled.div.attrs(props => ({
 	role: 'tabpanel',
-	id: ({ panelId }) => `panel:${panelId}`,
-	'aria-expanded': ({ selected }) => selected,
-})`
+	id: `panel:${props.panelId}`,
+	'aria-expanded': props.selected,
+}))`
 	position: relative;
 	padding: ${thickness.eight};
 

--- a/components/text-input-v2/react-select-async.jsx
+++ b/components/text-input-v2/react-select-async.jsx
@@ -170,8 +170,8 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
 			const options = passEmptyOptions
 				? []
 				: inputValue && loadedInputValue
-					? loadedOptions
-					: defaultOptions || [];
+				? loadedOptions
+				: defaultOptions || [];
 			return (
 				// $FlowFixMe
 				<SelectComponent


### PR DESCRIPTION
I got some nice warnings and errors while browsing the catalog. This fixes most of them.

Specifically, styled-components, i.e.:
```javascript
breadcrumbs.ts:155 Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "aria-level" on component "styled-header__Heading". 
 Error
    at http://localhost:4000/static/catalog.js:10556:331
    at StyledComponent.once [as warnAttrsFnObjectKeyDeprecated] (http://localhost:4000/static/catalog.js:10270:10)
    at http://localhost:4000/static/catalog.js:10669:22
    at Array.forEach (<anonymous>)
    at StyledComponent.buildExecutionContext (http://localhost:4000/static/catalog.js:10649:11)
    at StyledComponent.generateAndInjectStyles (http://localhost:4000/static/catalog.js:10702:65)
    at StyledComponent.renderInner (http://localhost:4000/static/catalog.js:10607:33)
    at updateContextConsumer (http://localhost:4000/static/catalog.js:148023:19)
    at beginWork (http://localhost:4000/static/catalog.js:148211:14)
    at performUnitOfWork (http://localhost:4000/static/catalog.js:151851:12)
    at workLoop (http://localhost:4000/static/catalog.js:151891:24)
    at renderRoot (http://localhost:4000/static/catalog.js:151974:7)
    at performWorkOnRoot (http://localhost:4000/static/catalog.js:152881:7)
    at performWork (http://localhost:4000/static/catalog.js:152793:7)
    at performSyncWork (http://localhost:4000/static/catalog.js:152767:3)
    at requestWork (http://localhost:4000/static/catalog.js:152636:5)
    at scheduleWork (http://localhost:4000/static/catalog.js:152450:5)
    at Object.enqueueSetState (http://localhost:4000/static/catalog.js:143884:5)
    at PageLoader.Component.setState (http://localhost:4000/static/catalog.js:131165:16)
    at http://localhost:4000/static/catalog.js:68991:14
```

And the listbox page:
```javascript
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ReactSpecimen`. See https://fb.me/react-warning-keys for more information.
    in ListItem (created by ReactSpecimen)
    in ReactSpecimen (created by SpecimenContainer)
    in div (created by Span)
    in Span (created by SpecimenContainer)
    in SpecimenContainer (created by MarkdownSpecimen)
    in MarkdownSpecimen (created by Page)
    in div (created by Page)
    in Page (created by PageRenderer)
    in div (created by PageRenderer)
    in PageRenderer (created by WrappedPageRenderer)
    in WrappedPageRenderer (created by PageLoader)
    in PageLoader
    in Unknown (created by RouterContext)
    in div (created by AppLayout)
    in div (created by AppLayout)
    in div (created by AppLayout)
    in AppLayout (created by App)
    in App (created by ConfiguredCatalogContext)
    in CatalogContext (created by ConfiguredCatalogContext)
    in ConfiguredCatalogContext (created by RouterContext)
    in RouterContext (created by Router)
    in ScrollBehaviorContext (created by Router)
    in Router (created by Catalog)
    in Catalog
```

The rest have to do with styled-components using its own version of Bootstrap, ag-grid not importing credentials properly or something, and the deprecated Typeahead component.