### PR TITLE
Fix padding on HelpBox Content

### DIFF
--- a/components/help-box/styled.jsx
+++ b/components/help-box/styled.jsx
@@ -55,7 +55,7 @@ export const HelpBox = variantCreator(
 		color: ${colors.flGray};
 
 		height: ${props => (props.large ? '230px' : '')};
-		padding: 14px 0px 14px 12px;
+		padding: 14px 16px 14px 12px;
 
 		flex-direction: ${props => (props.stacked ? 'column' : 'row')};
 		@media (max-width: ${mediaSizes.phone}) {
@@ -75,7 +75,7 @@ export const HelpBox = variantCreator(
 			order: 2;
 			align-items: center;
 
-			margin: ${props => (props.stacked ? '12px 16px 0px 0px' : '-7px 16px -7px 0px')};
+			margin: ${props => (props.stacked ? '12px 16px 0px 0px' : '-7px 0px -7px 16px')};
 			@media (max-width: ${mediaSizes.phone}) {
 				margin: 12px 0px 0px 0px;
 			}


### PR DESCRIPTION
Fix this problem with padding on the right:

![image](https://user-images.githubusercontent.com/31995444/60998211-535cbe00-a30d-11e9-9030-0da6f351216c.png)
