### PR TITLE
Add top border to table height when no headers

### DIFF
--- a/components/grid/base-table.jsx
+++ b/components/grid/base-table.jsx
@@ -118,7 +118,7 @@ export function BaseTable({
 	);
 
 	const rowCount = data ? data.length : 1;
-	const currentHeaderHeight = hideHeaders ? 0 : headerHeight;
+	const currentHeaderHeight = hideHeaders ? 1 : headerHeight;
 	const tableHeight =
 		(maxRows && maxRows < rowCount ? maxRows : rowCount) * (rowHeight || defaultRowHeight) +
 		tableHeightPadding +


### PR DESCRIPTION
One minor tweak (literally, 1 pixel) to a previous PR.  Table height is currently set 1 px too short when `hideHeaders` is `true` (there is a 1px border at top of table when header is hidden).  The problem manifests itself with a scrollbar appearing (allowing for 1px of scrolling).  Thus, this PR adds an extra pixel to the table height when `hideHeaders` is true to account for the 1px top border.