### PR TITLE
sizeColumnsToFit after component mounts

### DIFF
--- a/components/grid/base-table.jsx
+++ b/components/grid/base-table.jsx
@@ -130,6 +130,15 @@ export function BaseTable({
 		[setGridApi, setColumnApi, sortModel, filterText],
 	);
 
+	// Set proper column sizes once gridApi is available and component has mounted
+	// setTimeout necessary in certain browsers (e.g. Safari) to ensure ag-grid components have mounted
+	// See 'Sizing Columns By Default' here: https://www.ag-grid.com/javascript-grid-resizing/
+	useEffect(() => {
+		if (gridApi) {
+			setTimeout(() => gridApi.sizeColumnsToFit(), 0);
+		}
+	}, [gridApi]);
+
 	const rowCount = data ? data.length : 0;
 	const currentHeaderHeight = hideHeaders ? 1 : headerHeight;
 


### PR DESCRIPTION
This is intended to fix a safari (and perhaps other non-chrome browser) bug where columns do not 'find their size' on initial page load but instead only when the grid is resized after mounting.

See https://www.flowdock.com/app/logos/fl-comms/threads/lbTgyVKp5yo8o6gPKeKlREZLhJR