### PR TITLE
Parameter updates

### DIFF
--- a/components/input/styled.jsx
+++ b/components/input/styled.jsx
@@ -55,12 +55,15 @@ export const variationMap = {
 		height: ${({ styleOverrides }) => styleOverrides.fontSize || '20px'};
 		padding-bottom: ${thickness.four};
 		font-size: ${({ styleOverrides }) => styleOverrides.fontSize || '16px'};
+		line-height: 1;
+		padding-bottom: 0;
 
 		&:focus {
 			box-shadow: none;
+			border: none;
 			border-bottom: solid ${thickness.two}
 				${({ theme }) => theme.underlineColor || colors.blueBase};
-			outline: 0;
+			outline: none;
 		}
 	`,
 };

--- a/components/parameter-sentence/parameter-input.jsx
+++ b/components/parameter-sentence/parameter-input.jsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useCopyRefs } from '../shared-hooks';
 import { Input } from '../input';
 import * as Styled from './styled';
 
-export function ParameterInputBox(props) {
+export const ParameterInputBox = React.forwardRef((props, ref) => {
 	const {
 		defaultValue,
 		value,
@@ -17,6 +18,7 @@ export function ParameterInputBox(props) {
 	} = props;
 	const [isFocused, setIsFocused] = useState(false);
 	const inputRef = useRef();
+	const refGroup = useCopyRefs([ref, inputRef]);
 
 	/**
 	 * Due to a really strange firefox bug inputs with type=number will unfocus the input as soon as it is focused using the autofocus option.
@@ -45,7 +47,7 @@ export function ParameterInputBox(props) {
 			) : (
 				<Styled.InputContainer>
 					<Input
-						ref={inputRef}
+						ref={refGroup}
 						small
 						inline
 						value={value}
@@ -62,7 +64,7 @@ export function ParameterInputBox(props) {
 			)}
 		</Styled.Container>
 	);
-}
+});
 
 ParameterInputBox.propTypes = {
 	defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/components/parameter-sentence/styled.jsx
+++ b/components/parameter-sentence/styled.jsx
@@ -14,6 +14,9 @@ const selectStyling = css`
 	color: ${colors.gray66};
 	${props => `color: ${props.isOpen ? colors.blueActive : colors.gray66}`};
 	font-family: inherit;
+	border-radius: 0;
+	line-height: 1;
+	padding-bottom: 2px;
 
 	&:hover {
 		&:not(:focus) {
@@ -65,6 +68,7 @@ export const InputContainer = styled.div`
 	z-index: 0;
 	position: absolute;
 	bottom: ${inputOffset};
+	padding: 0;
 
 	&& > input::-webkit-outer-spin-button,
 	input::-webkit-inner-spin-button {

--- a/components/shared-hooks/index.js
+++ b/components/shared-hooks/index.js
@@ -2,3 +2,4 @@ export { useId } from './use-id';
 export { useBasicMap } from './use-basic-map';
 export { useFocusAwayHandler, useAddInboundsElement } from './use-focus-away-handler';
 export { useDebouncedCallback } from './use-debounced-callback';
+export { useCopyRefs } from './use-copy-refs';

--- a/components/shared-hooks/use-copy-refs.js
+++ b/components/shared-hooks/use-copy-refs.js
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+
+export function useCopyRefs(refs) {
+	const copy = useCallback(
+		ref => {
+			if (refs) {
+				for (const item of refs) {
+					if (item) {
+						if (typeof item === 'function') {
+							item(ref);
+						} else {
+							item.current = ref;
+						}
+					}
+				}
+			}
+		},
+		[refs],
+	);
+
+	return copy;
+}


### PR DESCRIPTION
Would allowing the return to be used as a ref be neat, or not work like it does in my head? There would be some weird side effects if it was used as a dependency I suppose.
Like the following:

```
export function useCopyRefs(refs) {
        const usableRef = useRef();
	const copy = useCallback(
		ref => {
			if (refs) {
				for (const item of refs) {
					if (item) {
						if (typeof item === 'function') {
							item(ref);
						} else {
							item.current = ref;
						}
					}
				}
			}
		},
		[refs],
	);

        copy.current = usableRef.current;
 	return copy;
}
```