### PR TITLE
Expose minHeight and maxHeight options for table size

### DIFF
--- a/components/grid/base-table.jsx
+++ b/components/grid/base-table.jsx
@@ -141,14 +141,13 @@ export function BaseTable({
 			  tableHeightPadding +
 			  currentHeaderHeight
 			: noRowsDefaultTableHeight;
-	const tableHeight =
-		minHeight && calculatedTableHeight < minHeight
-			? minHeight
-			: maxHeight && calculatedTableHeight > maxHeight
-			? maxHeight
-			: calculatedTableHeight;
 	return (
-		<Styled.GridContainer className="ag-theme-faithlife" height={tableHeight}>
+		<Styled.GridContainer
+			className="ag-theme-faithlife"
+			height={calculatedTableHeight}
+			minHeight={minHeight}
+			maxHeight={maxHeight}
+		>
 			<AgGridReact
 				rowData={data}
 				onGridReady={handleGridReady}

--- a/components/grid/base-table.jsx
+++ b/components/grid/base-table.jsx
@@ -6,7 +6,7 @@ import * as Styled from './styled';
 
 const defaultRowHeight = 45;
 const headerHeight = defaultRowHeight - 5;
-const noRowsTableHeight = 200;
+const noRowsDefaultTableHeight = 200;
 
 /** A wrapper of ag-grid with some boilerplate code to handle initialization and sorting/ filtering */
 export function BaseTable({
@@ -17,6 +17,8 @@ export function BaseTable({
 	onRowClick,
 	isSmallViewport,
 	maxRows,
+	maxHeight,
+	minHeight,
 	children,
 	data,
 	/** IGridOptions interface from ag-grid */
@@ -133,12 +135,18 @@ export function BaseTable({
 	const rowCount = data ? data.length : 0;
 	const currentHeaderHeight = hideHeaders ? 1 : headerHeight;
 
-	const tableHeight =
+	const calculatedTableHeight =
 		rowCount !== 0
 			? (maxRows && maxRows < rowCount ? maxRows : rowCount) * (rowHeight || defaultRowHeight) +
 			  tableHeightPadding +
 			  currentHeaderHeight
-			: noRowsTableHeight;
+			: noRowsDefaultTableHeight;
+	const tableHeight =
+		minHeight && calculatedTableHeight < minHeight
+			? minHeight
+			: maxHeight && calculatedTableHeight > maxHeight
+			? maxHeight
+			: calculatedTableHeight;
 	return (
 		<Styled.GridContainer className="ag-theme-faithlife" height={tableHeight}>
 			<AgGridReact

--- a/components/grid/simple-table.jsx
+++ b/components/grid/simple-table.jsx
@@ -11,6 +11,8 @@ export function SimpleTable({
 	sortModel,
 	updateSortModel,
 	maxRows,
+	maxHeight,
+	minHeight,
 	rowSelectionType,
 	hideHeaders,
 	rowHeight,
@@ -31,6 +33,8 @@ export function SimpleTable({
 			updateSortModel={updateSortModel}
 			filterText={filterText}
 			maxRows={maxRows}
+			maxHeight={maxHeight}
+			minHeight={minHeight}
 			rowSelectionType={rowSelectionType}
 			hideHeaders={hideHeaders}
 			rowHeight={rowHeight}

--- a/components/grid/styled.jsx
+++ b/components/grid/styled.jsx
@@ -3,4 +3,6 @@ import styled from 'styled-components';
 // Base Table
 export const GridContainer = styled.div`
 	height: ${({ height }) => height}px;
+	${({ maxHeight }) => maxHeight && `max-height: ${maxHeight}`};
+	${({ minHeight }) => minHeight && `min-height: ${minHeight}`};
 `;


### PR DESCRIPTION
Max height may be a more desirable property than maxRows in some cases (e.g. if desired height does not align perfectly with row heights), so it would be useful to expose both options for setting max table height.

Min height allows consumers to ensure that table does not shrink below a certain size.  Another option here would be to standardize this within the shared component (i.e. don't allow an option here)...either way, it seems a min height needs to be set, at least on large viewport (otherwise table w/ limited number of rows can get so short that options menu cannot fit on right click).