### PR TITLE
Add grid options to simple table?

### DIFF
--- a/components/grid/simple-table.jsx
+++ b/components/grid/simple-table.jsx
@@ -15,6 +15,7 @@ export function SimpleTable({
 	hideHeaders,
 	rowHeight,
 	handleGetRowId,
+	gridOptions,
 }) {
 	const { gridApi, setGridApi, columnApi, setColumnApi } = useTableState();
 
@@ -35,6 +36,7 @@ export function SimpleTable({
 			hideHeaders={hideHeaders}
 			rowHeight={rowHeight}
 			handleGetRowId={handleGetRowId}
+			gridOptions={gridOptions}
 		>
 			{children}
 		</BaseTable>


### PR DESCRIPTION
Adding grid options to the simple table. Was leaving it out purposeful? It would be nice to be able to pass in a `getRowHeight` callback in the `gridOptions` to allow for variable row height.