### PR TITLE
Add mixed state to checkboxes

### DIFF
--- a/catalog/checkbox/variations.md
+++ b/catalog/checkbox/variations.md
@@ -18,13 +18,12 @@ state: { isChecked: false }
 
 ```react
 showSource: true
-state: { isMixed: true, isChecked: false }
+state: { isChecked: 'mixed' }
 ---
 <CheckboxDemo>
 	<Checkbox
-		onClick={() => setState({ isMixed: !state.isMixed && !state.isChecked, isChecked: state.isMixed })}
+		onClick={() => setState({ isChecked: ({ [true]: false, [false]: 'mixed', mixed: true })[state.isChecked] })}
 		isChecked={state.isChecked}
-		isMixed={state.isMixed}
 		title={'Click me'}
 		type="button"
 	/>

--- a/catalog/checkbox/variations.md
+++ b/catalog/checkbox/variations.md
@@ -14,6 +14,23 @@ state: { isChecked: false }
 </CheckboxDemo>
 ```
 
+### Mixed value
+
+```react
+showSource: true
+state: { isMixed: true, isChecked: false }
+---
+<CheckboxDemo>
+	<Checkbox
+		onClick={() => setState({ isMixed: !state.isMixed && !state.isChecked, isChecked: state.isMixed })}
+		isChecked={state.isChecked}
+		isMixed={state.isMixed}
+		title={'Click me'}
+		type="button"
+	/>
+</CheckboxDemo>
+```
+
 ### Custom theme
 
 ```react

--- a/components/check-box/checkbox-content.jsx
+++ b/components/check-box/checkbox-content.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styled from './styled';
 
-export function CheckboxContent({ isChecked, title, children, disabled }) {
+export function CheckboxContent({ isChecked, isMixed, title, children, disabled }) {
 	return (
 		<React.Fragment>
 			<Styled.CheckboxDiv disabled={disabled}>
-				<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} />
+				<Styled.CheckedIndicator isChecked={isChecked} isMixed={isMixed} disabled={disabled} />
 			</Styled.CheckboxDiv>
 			{title && <Styled.Label>{title}</Styled.Label>}
 			{children && <Styled.Label>{children}</Styled.Label>}

--- a/components/check-box/checkbox-content.jsx
+++ b/components/check-box/checkbox-content.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styled from './styled';
 
-export function CheckboxContent({ isChecked, isMixed, title, children, disabled }) {
+export function CheckboxContent({ isChecked, title, children, disabled }) {
 	return (
 		<React.Fragment>
 			<Styled.CheckboxDiv disabled={disabled}>
-				<Styled.CheckedIndicator isChecked={isChecked} isMixed={isMixed} disabled={disabled} />
+				<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} />
 			</Styled.CheckboxDiv>
 			{title && <Styled.Label>{title}</Styled.Label>}
 			{children && <Styled.Label>{children}</Styled.Label>}
@@ -17,6 +17,6 @@ export function CheckboxContent({ isChecked, isMixed, title, children, disabled 
 CheckboxContent.propTypes = {
 	children: PropTypes.node,
 	title: PropTypes.string,
-	isChecked: PropTypes.bool,
+	isChecked: PropTypes.oneOf([true, false, 'mixed']),
 	disabled: PropTypes.bool,
 };

--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -13,6 +13,7 @@ export class Checkbox extends Component {
 		onMouseUp: PropTypes.func,
 		title: PropTypes.string,
 		isChecked: PropTypes.bool,
+		isMixed: PropTypes.bool,
 		theme: PropTypes.shape({
 			primary: PropTypes.string,
 			border: PropTypes.string,
@@ -42,7 +43,17 @@ export class Checkbox extends Component {
 	componentRef = React.createRef();
 
 	render() {
-		const { onClick, title, isChecked, theme, type, children, className, disabled } = this.props;
+		const {
+			onClick,
+			title,
+			isChecked,
+			isMixed,
+			theme,
+			type,
+			children,
+			className,
+			disabled,
+		} = this.props;
 		return (
 			<ThemeProvider theme={theme}>
 				<Styled.CheckboxContainer
@@ -52,10 +63,15 @@ export class Checkbox extends Component {
 					type={type}
 					className={className}
 					role={'checkbox'}
-					aria-checked={isChecked}
+					aria-checked={isMixed ? 'mixed' : isChecked}
 					disabled={disabled}
 				>
-					<CheckboxContent isChecked={isChecked} title={title} disabled={disabled}>
+					<CheckboxContent
+						isChecked={isChecked}
+						isMixed={isMixed}
+						title={title}
+						disabled={disabled}
+					>
 						{children}
 					</CheckboxContent>
 				</Styled.CheckboxContainer>

--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -12,8 +12,7 @@ export class Checkbox extends Component {
 		onClick: PropTypes.func.isRequired,
 		onMouseUp: PropTypes.func,
 		title: PropTypes.string,
-		isChecked: PropTypes.bool,
-		isMixed: PropTypes.bool,
+		isChecked: PropTypes.oneOf([true, false, 'mixed']),
 		theme: PropTypes.shape({
 			primary: PropTypes.string,
 			border: PropTypes.string,
@@ -43,17 +42,7 @@ export class Checkbox extends Component {
 	componentRef = React.createRef();
 
 	render() {
-		const {
-			onClick,
-			title,
-			isChecked,
-			isMixed,
-			theme,
-			type,
-			children,
-			className,
-			disabled,
-		} = this.props;
+		const { onClick, title, isChecked, theme, type, children, className, disabled } = this.props;
 		return (
 			<ThemeProvider theme={theme}>
 				<Styled.CheckboxContainer
@@ -63,15 +52,10 @@ export class Checkbox extends Component {
 					type={type}
 					className={className}
 					role={'checkbox'}
-					aria-checked={isMixed ? 'mixed' : isChecked}
+					aria-checked={isChecked}
 					disabled={disabled}
 				>
-					<CheckboxContent
-						isChecked={isChecked}
-						isMixed={isMixed}
-						title={title}
-						disabled={disabled}
-					>
+					<CheckboxContent isChecked={isChecked} title={title} disabled={disabled}>
 						{children}
 					</CheckboxContent>
 				</Styled.CheckboxContainer>

--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -57,7 +57,30 @@ export const CheckboxContainer = styled.button`
 `;
 
 export const isCheckedStyles = `&:after {
+background-repeat: no-repeat;
+content: '';
+position: absolute;
+top: 1.5px;
+left: 1.5px;
+height: 9.6px;
+width: 9.6px;
 opacity: 1;
+}`;
+
+export const isMixedStyles = `
+display: flex;
+justify-content: center;
+align-items: center;
+
+&:after {
+	top: -12px;
+	position: absolute;
+	font-size: 24px;
+	font-weight: bold;
+	left: 2px;
+	background-image: none;
+	content: '-';
+	opacity: 1;
 }`;
 
 export const CheckedIndicator = styled.div`
@@ -71,21 +94,15 @@ export const CheckedIndicator = styled.div`
 	${props => (props.disabled ? 'cursor: default;' : '')};
 
 	&:after {
-	background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%208%208'%3E%3Cpath%20fill='${props =>
-		encodeURIComponent(
-			props.theme.primary,
-		)}'%20d='M6.564.75l-3.59%203.612-1.538-1.55L0%204.26%202.974%207.25%208%202.193z'/%3E%3C/svg%3E");
-		background-repeat: no-repeat;
-		content: '';
-		position: absolute;
-		top: 1.5px;
-		left: 1.5px;
-		height: 9.6px;
-		width: 9.6px;
+		background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%208%208'%3E%3Cpath%20fill='${props =>
+			encodeURIComponent(
+				props.theme.primary,
+			)}'%20d='M6.564.75l-3.59%203.612-1.538-1.55L0%204.26%202.974%207.25%208%202.193z'/%3E%3C/svg%3E");
+		color: ${props => props.theme.primary};
 		opacity: 0;
 	}
 
-	${props => (props.isChecked ? isCheckedStyles : '')};
+	${props => (props.isMixed ? isMixedStyles : props.isChecked ? isCheckedStyles : '')};
 `;
 
 export const Label = styled.div`

--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -67,19 +67,20 @@ width: 9.6px;
 opacity: 1;
 }`;
 
-export const isMixedStyles = `
+export const isMixedStyles = props => `
 display: flex;
 justify-content: center;
 align-items: center;
 
 &:after {
-	top: -12px;
+	display: block;
+	width: 10px;
+	height: 2px;
 	position: absolute;
-	font-size: 24px;
-	font-weight: bold;
-	left: 2px;
-	background-image: none;
-	content: '-';
+	top: 5px;
+	left: 1px;
+	background: ${props.theme.primary};
+	content: '';
 	opacity: 1;
 }`;
 
@@ -102,7 +103,8 @@ export const CheckedIndicator = styled.div`
 		opacity: 0;
 	}
 
-	${props => (props.isMixed ? isMixedStyles : props.isChecked ? isCheckedStyles : '')};
+	${props =>
+		props.isChecked === 'mixed' ? isMixedStyles(props) : props.isChecked ? isCheckedStyles : ''};
 `;
 
 export const Label = styled.div`


### PR DESCRIPTION
To support nested options where a checkbox may be a header and need to reflect a partially-checked state, this adds support for a mixed mode including aria changes.

Addresses issue: https://github.com/Faithlife/styled-ui/issues/230