### PR TITLE
allow style override of date picker input border color

### DIFF
--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -151,10 +151,7 @@ export class DatePickerInput extends PureComponent {
 		const defaultValue = defaultSelectedDate ? this.formatDate(defaultSelectedDate) : '';
 		const formattedDate = selectedDate ? this.formatDate(selectedDate) : defaultValue;
 		const value = text ? text : formattedDate;
-		const inputStyleOverrides = {
-			width: styleOverrides.inputWidth,
-			borderColor: styleOverrides.inputBorderColor,
-		};
+		const inputStyleOverrides = { width: styleOverrides.inputWidth };
 		const popoverStyleOverrides = {
 			hideShadow: styleOverrides.hideShadow,
 			width: styleOverrides.width,
@@ -173,6 +170,7 @@ export class DatePickerInput extends PureComponent {
 						onFocus={this.handleFocus}
 						value={value}
 						disabled={disabled}
+						borderColor={styleOverrides.inputBorderColor}
 						styleOverrides={inputStyleOverrides}
 					/>
 					<Styled.CalendarButton ref={this.icon} onClick={!disabled ? this.openCalendar : null}>

--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -36,6 +36,7 @@ export class DatePickerInput extends PureComponent {
 		/** Style overrides, inputWidth is applied to the input */
 		styleOverrides: PropTypes.shape({
 			inputWidth: PropTypes.string,
+			inputBorderColor: PropTypes.string,
 			hideShadow: PropTypes.bool,
 			width: PropTypes.string,
 			padding: PropTypes.string,
@@ -152,6 +153,7 @@ export class DatePickerInput extends PureComponent {
 		const value = text ? text : formattedDate;
 		const inputStyleOverrides = {
 			width: styleOverrides.inputWidth,
+			borderColor: styleOverrides.inputBorderColor,
 		};
 		const popoverStyleOverrides = {
 			hideShadow: styleOverrides.hideShadow,

--- a/components/input/component.jsx
+++ b/components/input/component.jsx
@@ -113,6 +113,11 @@ ${({ theme, styleOverrides = {} }) => css`
 	border-radius: ${theme.radii[1]};
 	border-color: ${theme.colors.inputBorderColor};
 
+	${'borderColor' in styleOverrides &&
+		css`
+			border-color: ${styleOverrides.borderColor};
+		`}
+
 	${'height' in styleOverrides &&
 		css`
 			height: ${styleOverrides.height};

--- a/components/input/component.jsx
+++ b/components/input/component.jsx
@@ -113,11 +113,6 @@ ${({ theme, styleOverrides = {} }) => css`
 	border-radius: ${theme.radii[1]};
 	border-color: ${theme.colors.inputBorderColor};
 
-	${'borderColor' in styleOverrides &&
-		css`
-			border-color: ${styleOverrides.borderColor};
-		`}
-
 	${'height' in styleOverrides &&
 		css`
 			height: ${styleOverrides.height};


### PR DESCRIPTION
This PR was created to enable this functionality in ChMS:

<img width="446" alt="Screen Shot 2019-09-10 at 10 24 58 AM" src="https://user-images.githubusercontent.com/9691017/65627113-8bc27e80-df83-11e9-839a-89564fdbc56b.png">
