### PR TITLE
Add hover colors for anchor button overrides.

### DIFF
--- a/catalog/button/anchor-button.md
+++ b/catalog/button/anchor-button.md
@@ -15,6 +15,9 @@ showSource: true
 	</AnchorButton>
 	<AnchorButton href="#settings" variant="primary" condensed size="small" icon={<GearIcon />} />
 	<AnchorButton href="#settings" variant="primary" size="small">Settings</AnchorButton>
-	<AnchorButton href="#settings" primaryTransparent size="small">Settings</AnchorButton>
+	<AnchorButton href="#settings" variant="minor" size="small">Settings</AnchorButton>
+	<AnchorButton href="#settings" variant="minorTransparent" size="small">Settings</AnchorButton>
+	<AnchorButton href="#settings" variant="primaryOutline" size="small">Settings</AnchorButton>
+	<AnchorButton href="#settings" variant="primaryTransparent" size="small">Settings</AnchorButton>
 </ButtonDemo>
 ```

--- a/components/button/component.jsx
+++ b/components/button/component.jsx
@@ -71,7 +71,7 @@ export const Button = React.forwardRef(function Button(props, ref) {
 				}
 				disabledColor={
 					{
-						minor: 'gray4',
+						minor: 'gray22',
 						minorTransparent: 'gray22',
 					}[variant] || 'blue2'
 				}

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -77,6 +77,11 @@ export const Button = styled.button`
 					primary: {
 						border: '1px solid',
 						color: 'white',
+						'@media (hover: hover)': {
+							'&:hover': {
+								color: disabled || 'white',
+							},
+						},
 					},
 					primaryOutline: {
 						border: '1px solid',
@@ -98,6 +103,11 @@ export const Button = styled.button`
 					minor: {
 						border: '1px solid',
 						color: disabled ? 'gray34' : 'gray66',
+						'@media (hover: hover)': {
+							'&:hover': {
+								color: disabled || 'gray66',
+							},
+						},
 					},
 					minorTransparent: {
 						border: '1px solid transparent',

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -79,7 +79,7 @@ export const Button = styled.button`
 						color: 'white',
 						'@media (hover: hover)': {
 							'&:hover': {
-								color: disabled || 'white',
+								color: 'white',
 							},
 						},
 					},
@@ -88,7 +88,7 @@ export const Button = styled.button`
 						background: 'none',
 						'@media (hover: hover)': {
 							'&:hover': {
-								color: disabled || 'white',
+								color: disabled ? 'blue2' : 'white',
 							},
 						},
 						'&:active': {
@@ -102,10 +102,10 @@ export const Button = styled.button`
 					},
 					minor: {
 						border: '1px solid',
-						color: disabled ? 'gray34' : 'gray66',
+						color: disabled ? 'gray22' : 'gray66',
 						'@media (hover: hover)': {
 							'&:hover': {
-								color: disabled || 'gray66',
+								color: disabled ? 'gray22' : 'gray66',
 							},
 						},
 					},


### PR DESCRIPTION
Currently base `a.hover` styles from faithlife.com are coming through on anchor buttons with the 5.19 update.

I believe this is the correct way to set default hover states on buttons.