### PR TITLE
modify ProductDrawerDropdown to stay in viewport on displays

### DIFF
--- a/components/product-drawer/product-drawer-dropdown/styled.jsx
+++ b/components/product-drawer/product-drawer-dropdown/styled.jsx
@@ -33,11 +33,16 @@ export const ProductDrawerDropdown = styled.div`
 		left: auto;
 		bottom: auto;
 		top: auto;
+		transform: translateX(22%);
 		overflow-y: auto;
 		animation-duration: 300ms;
 		animation-timing-function: cubic-bezier(0.33, 0, 0, 1);
 		animation-fill-mode: forwards;
 		animation-name: ${dropdownSlideDownFadeIn};
+	}
+
+	@media (min-width: ${mediaSizes.desktop}) {
+		transform: translateX(0);
 	}
 
 	right: 0;


### PR DESCRIPTION
for issue https://github.com/Faithlife/styled-ui/issues/244 from https://faithlife.atlassian.net/browse/SITES-5828

translating the ProductDrawerDropdown a bit to the left between 768px & 992px to make sure it remains fully in view for those viewports, then override that styling when viewport is above 992px