### PR TITLE
Demonstrate tooltip issue.

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -598,16 +598,21 @@ const components = [
 				title: 'Popover Variations',
 				content: pageLoader(() => import('./popover/variations.md')),
 				imports: {
+					Box,
 					Button,
+					GearIcon,
 					Popover,
 					PopoverBase,
 					Tooltip,
 					PopoverManager,
 					PopoverReference,
 					PopoverDemo: styled.div`
-						display: flex;
-						align-items: flex-start;
+						display: grid;
+						grid-auto-flow: column;
+						grid-gap: 12px;
+						grid-auto-columns: min-content;
 						justify-content: space-between;
+						align-items: center;
 					`,
 					PopoverOverflowDemo: styled.div`
 						display: flex;

--- a/catalog/popover/variations.md
+++ b/catalog/popover/variations.md
@@ -144,5 +144,10 @@ state: { isOpen: false }
 	<Tooltip content={<StyledDiv>Hello!</StyledDiv>}>
 		<Button variant="primary" size="medium">Tooltip with jsx</Button>
 	</Tooltip>
+	<Box minWidth="min-content">
+	<Tooltip content={<StyledDiv>Hello!</StyledDiv>}>
+		<GearIcon />
+	</Tooltip>
+	</Box>
 </PopoverDemo>
 ```

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -40,7 +40,7 @@ module.exports = {
 				ignore: ['after-comment'],
 			},
 		],
-		'unit-whitelist': ['em', 'rem', '%', 's', 'px', 'deg', 'ms', 'vh', 'vw'],
+		'unit-whitelist': ['em', 'rem', '%', 's', 'px', 'deg', 'ms', 'vh', 'vw', 'fr'],
 		'value-no-vendor-prefix': true,
 	},
 };


### PR DESCRIPTION
Tooltips inside of CSS grid contains aren't staying open reliably.
If I'm very careful with my cursor, I can hit an edge of the containing div and it will stay open, but if the cursor is fully over the icon the tooltip will flash open and then disappear.

I don't yet understand why this is happening.