### PR TITLE
Add Home/End key handler to Select component

### DIFF
--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -134,6 +134,34 @@ function noOptionsMessage({ inputValue }) {
 	return inputValue ? 'No options' : null;
 }
 
+function handleKeyDown(e) {
+	const evt = { ...e };
+	switch (evt.key) {
+		case 'Home': {
+			evt.preventDefault();
+			if (evt.shiftKey) {
+				evt.target.selectionStart = 0;
+			} else {
+				evt.target.setSelectionRange(0, 0);
+			}
+			break;
+		}
+		case 'End': {
+			evt.preventDefault();
+			const len = evt.target.value.length;
+			if (evt.shiftKey) {
+				evt.target.selectionEnd = len;
+			} else {
+				evt.target.setSelectionRange(len, len);
+			}
+			break;
+		}
+		default: {
+			break;
+		}
+	}
+}
+
 /** Autocomplete control based on react-select */
 export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();
@@ -145,6 +173,7 @@ export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 			theme={selectTheme}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
+			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
@@ -164,6 +193,7 @@ export const CreatableSelect = React.forwardRef(({ components = {}, ...props }, 
 			formatCreateLabel={node => <span>New entry: {node}</span>}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
+			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
@@ -184,6 +214,7 @@ export const AsyncCreatableSelect = React.forwardRef(({ components = {}, ...prop
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			formatCreateLabel={node => <span>New entry: {node}</span>}
 			noOptionsMessage={noOptionsMessage}
+			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
@@ -202,6 +233,7 @@ export const AsyncSelect = React.forwardRef(({ components = {}, ...props }, ref)
 			theme={selectTheme}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
+			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -135,36 +135,23 @@ function noOptionsMessage({ inputValue }) {
 }
 
 function handleKeyDown(e, onConsumerKeyDown) {
-	const { nodeName, type } = e.target;
+	const { nodeName, type, value } = e.target;
 	if (onConsumerKeyDown) {
 		onConsumerKeyDown(e);
 		if (e.defaultPrevented) {
 			return;
 		}
 	}
-	switch (e.key) {
-		case nodeName === 'input' && type === 'text' && 'Home': {
+
+	if (nodeName === 'input' && type === 'text') {
+		const selectionIndex = e.key === 'Home' ? 0 : e.key === 'End' ? value.length : null;
+
+		if (selectionIndex !== null) {
 			if (e.shiftKey) {
-				e.target.selectionStart = 0;
+				e.target.selectionEnd = selectionIndex;
 			} else {
-				e.target.setSelectionRange(0, 0);
+				e.target.setSelectionRange(selectionIndex, selectionIndex);
 			}
-			break;
-		}
-		case nodeName === 'input' && type === 'text' && 'End': {
-			const len = e.target.value.length;
-			if (e.shiftKey) {
-				e.target.selectionEnd = len;
-			} else {
-				e.target.setSelectionRange(len, len);
-			}
-			break;
-		}
-		default: {
-			if (onConsumerKeyDown) {
-				onConsumerKeyDown(e);
-			}
-			break;
 		}
 	}
 }

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -134,11 +134,17 @@ function noOptionsMessage({ inputValue }) {
 	return inputValue ? 'No options' : null;
 }
 
-function handleKeyDown(e) {
+function handleKeyDown(e, onConsumerKeyDown) {
 	const evt = { ...e };
+	if (evt.defaultPrevented) {
+		if (onConsumerKeyDown) {
+			onConsumerKeyDown(e);
+		}
+		return;
+	}
+
 	switch (evt.key) {
 		case 'Home': {
-			evt.preventDefault();
 			if (evt.shiftKey) {
 				evt.target.selectionStart = 0;
 			} else {
@@ -147,7 +153,6 @@ function handleKeyDown(e) {
 			break;
 		}
 		case 'End': {
-			evt.preventDefault();
 			const len = evt.target.value.length;
 			if (evt.shiftKey) {
 				evt.target.selectionEnd = len;
@@ -157,6 +162,9 @@ function handleKeyDown(e) {
 			break;
 		}
 		default: {
+			if (onConsumerKeyDown) {
+				onConsumerKeyDown(e);
+			}
 			break;
 		}
 	}
@@ -165,6 +173,7 @@ function handleKeyDown(e) {
 /** Autocomplete control based on react-select */
 export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();
+	const onConsumerKeyDown = props.onKeyDown;
 
 	return (
 		<ReactSelect
@@ -173,10 +182,10 @@ export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 			theme={selectTheme}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
-			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
+			onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 		/>
 	);
 });

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -179,6 +179,7 @@ export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 /** The same as `Select`, but allows new entries. */
 export const CreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();
+	const onConsumerKeyDown = props.onKeyDown;
 
 	return (
 		<ReactSelectCreatable
@@ -188,10 +189,10 @@ export const CreatableSelect = React.forwardRef(({ components = {}, ...props }, 
 			formatCreateLabel={node => <span>New entry: {node}</span>}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
-			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
+			onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 		/>
 	);
 });
@@ -199,6 +200,7 @@ export const CreatableSelect = React.forwardRef(({ components = {}, ...props }, 
 /** The same as `Select`, but allows new entries and fetches data asynchronously. */
 export const AsyncCreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();
+	const onConsumerKeyDown = props.onKeyDown;
 
 	return (
 		<ReactSelectAsyncCreatable
@@ -209,10 +211,10 @@ export const AsyncCreatableSelect = React.forwardRef(({ components = {}, ...prop
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			formatCreateLabel={node => <span>New entry: {node}</span>}
 			noOptionsMessage={noOptionsMessage}
-			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
+			onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 		/>
 	);
 });
@@ -220,6 +222,7 @@ export const AsyncCreatableSelect = React.forwardRef(({ components = {}, ...prop
 /** The same as `Select`, but fetches options asynchronously. */
 export const AsyncSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();
+	const onConsumerKeyDown = props.onKeyDown;
 
 	return (
 		<ReactSelectAsync
@@ -228,10 +231,10 @@ export const AsyncSelect = React.forwardRef(({ components = {}, ...props }, ref)
 			theme={selectTheme}
 			components={{ DropdownIndicator, ...defaultComponents, ...components }}
 			noOptionsMessage={noOptionsMessage}
-			onKeyDown={handleKeyDown}
 			menuPortalTarget={body}
 			{...props}
 			styles={selectStyles(props)}
+			onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 		/>
 	);
 });

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -135,15 +135,15 @@ function noOptionsMessage({ inputValue }) {
 }
 
 function handleKeyDown(e, onConsumerKeyDown) {
+	const { nodeName, type } = e.target;
 	if (onConsumerKeyDown) {
 		onConsumerKeyDown(e);
 		if (e.defaultPrevented) {
 			return;
 		}
 	}
-
 	switch (e.key) {
-		case 'Home': {
+		case nodeName === 'input' && type === 'text' && 'Home': {
 			if (e.shiftKey) {
 				e.target.selectionStart = 0;
 			} else {
@@ -151,7 +151,7 @@ function handleKeyDown(e, onConsumerKeyDown) {
 			}
 			break;
 		}
-		case 'End': {
+		case nodeName === 'input' && type === 'text' && 'End': {
 			const len = e.target.value.length;
 			if (e.shiftKey) {
 				e.target.selectionEnd = len;

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -136,11 +136,11 @@ function noOptionsMessage({ inputValue }) {
 
 function handleKeyDown(e, onConsumerKeyDown) {
 	const evt = { ...e };
-	if (evt.defaultPrevented) {
-		if (onConsumerKeyDown) {
-			onConsumerKeyDown(e);
+	if (onConsumerKeyDown) {
+		onConsumerKeyDown(e);
+		if (evt.defaultPrevented) {
+			return;
 		}
-		return;
 	}
 
 	switch (evt.key) {

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -135,29 +135,28 @@ function noOptionsMessage({ inputValue }) {
 }
 
 function handleKeyDown(e, onConsumerKeyDown) {
-	const evt = { ...e };
 	if (onConsumerKeyDown) {
 		onConsumerKeyDown(e);
-		if (evt.defaultPrevented) {
+		if (e.defaultPrevented) {
 			return;
 		}
 	}
 
-	switch (evt.key) {
+	switch (e.key) {
 		case 'Home': {
-			if (evt.shiftKey) {
-				evt.target.selectionStart = 0;
+			if (e.shiftKey) {
+				e.target.selectionStart = 0;
 			} else {
-				evt.target.setSelectionRange(0, 0);
+				e.target.setSelectionRange(0, 0);
 			}
 			break;
 		}
 		case 'End': {
-			const len = evt.target.value.length;
-			if (evt.shiftKey) {
-				evt.target.selectionEnd = len;
+			const len = e.target.value.length;
+			if (e.shiftKey) {
+				e.target.selectionEnd = len;
 			} else {
-				evt.target.setSelectionRange(len, len);
+				e.target.setSelectionRange(len, len);
 			}
 			break;
 		}


### PR DESCRIPTION
- Type a word in Select
- Press Home/End key

Current behavior:  focus on the dropdown items (default by `react-select`)
Expected behavior:  focus on the input, cursor move to begin or end of the input value