### PR TITLE
Fix Group Selector bottom border not showing by adding padding

### DIFF
--- a/components/group-selector/styled.jsx
+++ b/components/group-selector/styled.jsx
@@ -139,6 +139,7 @@ export const LargeScrollView = styled(ScrollArea)`
 
 	.${LargeScrollViewContentClass} {
 		padding-top: ${props => (props.hideTitle ? '0' : '30px')};
+		padding-bottom: 4px;
 		position: unset;
 	}
 `;


### PR DESCRIPTION
Should be visible in the catalog by toggling the padding in dev tools. 

context:
https://git.faithlife.dev/Logos/Stores/pull/1049
https://github.com/Faithlife/styled-ui/issues/262
<img width="382" alt="Screen Shot 2019-10-22 at 4 33 20 PM" src="https://user-images.githubusercontent.com/16234958/67343461-3037d200-f4ea-11e9-8ce0-e16fc45d51b1.png">


