### PR TITLE
allow empty string in date picker input

### DIFF
--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -150,7 +150,7 @@ export class DatePickerInput extends PureComponent {
 
 		const defaultValue = defaultSelectedDate ? this.formatDate(defaultSelectedDate) : '';
 		const formattedDate = selectedDate ? this.formatDate(selectedDate) : defaultValue;
-		const value = text ? text : formattedDate;
+		const value = text !== null && text !== undefined ? text : formattedDate;
 		const inputStyleOverrides = { width: styleOverrides.inputWidth };
 		const popoverStyleOverrides = {
 			hideShadow: styleOverrides.hideShadow,


### PR DESCRIPTION
Currently, the Date Picker Input component does not allow the input field to be cleared.

Demo from catalog: http://g.recordit.co/aB7oah0sIe.gif

This change allows an empty string in the input instead of deferring back to the default formatted date.