### PR TITLE
Resize columns on paginated-grid when page changes.

### DIFF
--- a/components/grid/paginated-grid.jsx
+++ b/components/grid/paginated-grid.jsx
@@ -16,9 +16,12 @@ export function PaginatedGrid(props) {
 	}, [gridApi, currentPageNumber]);
 
 	const handlePaginationChanged = useCallback(() => {
-		if (gridApi && onPageNumberChange) {
-			const pageNumber = gridApi.paginationGetCurrentPage();
-			onPageNumberChange(pageNumber);
+		if (gridApi) {
+			gridApi.sizeColumnsToFit();
+			if (onPageNumberChange) {
+				const pageNumber = gridApi.paginationGetCurrentPage();
+				onPageNumberChange(pageNumber);
+			}
 		}
 	}, [gridApi, onPageNumberChange]);
 


### PR DESCRIPTION
If a scroll bar is necessary because the table height changed between pages, we don't want the scrollbar to overlap the right most column.