### PR TITLE
Add selectedDate prop to DatePickerInput component

### DIFF
--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -13,6 +13,8 @@ import * as Styled from './styled';
 export class DatePickerInput extends PureComponent {
 	static propTypes = {
 		defaultSelectedDate: PropTypes.instanceOf(Date),
+		/** Sets the selected date */
+		selectedDate: PropTypes.instanceOf(Date),
 		/** Functions that operate on a JS Date object.
 		 * The following functions must be provided:
 		 *
@@ -62,6 +64,13 @@ export class DatePickerInput extends PureComponent {
 			showCalendar: false,
 			selectedDate: this.props.defaultSelectedDate,
 		};
+	}
+
+	static getDerivedStateFromProps(nextProps, prevState) {
+		if (nextProps.selectedDate && prevState.selectedDate !== nextProps.selectedDate) {
+			return { ...prevState, selectedDate: nextProps.selectedDate };
+		}
+		return null;
 	}
 
 	componentDidUpdate(prevState) {


### PR DESCRIPTION
Add selectedDate prop to DatePickerInput component to allow higher order component to set the selected date after initial render.

[example usage](https://static1.faithlifecdn.com/v1/imageproxy/3ecf5837fa71754d3d64a4d644a5da80bf00f90e?url=http%3a%2f%2fg%2erecordit%2eco%2fRAeIShjSMx%2egif) of reassigning the end date in a duration picker when the initial date is set after the end date.