### PR TITLE
Fix FilterInput icon.

### DIFF
--- a/components/input/FilterInput.jsx
+++ b/components/input/FilterInput.jsx
@@ -43,7 +43,8 @@ const FilterInput = React.forwardRef(function FilterInput(
 					paddingRight={6}
 				/>
 				<Button
-					variant="minorTransparent"
+					variant="link"
+					size="small"
 					disabled={!value}
 					icon={value ? <Close /> : <Search />}
 					position="absolute"


### PR DESCRIPTION
The `size` prop is used by `styled-system` to set both `height` and `width`.
If we don't set the `size` prop on a v6 Button, it defaults to `small`,
which was overriding the `height=100%` we were setting in `<FilterInput>`.