### PR TITLE
Allow Product Drawer title override

### DIFF
--- a/catalog/product-drawer/product-drawer.jsx
+++ b/catalog/product-drawer/product-drawer.jsx
@@ -3,5 +3,5 @@ import { ProductDrawer } from '../../components/product-drawer';
 import resources from './resources.json';
 
 export const ProductDrawerWithResources = props => (
-	<ProductDrawer {...props} resources={resources} />
+	<ProductDrawer {...props} resources={{ ...resources, ...props.localizedResources }} />
 );

--- a/catalog/product-drawer/resources.json
+++ b/catalog/product-drawer/resources.json
@@ -27,7 +27,7 @@
 	"equipDescription": "A full suite of tools for church ministry",
 	"comingSoon": "Coming soon",
 	"more": "More",
-	"products": "Products",
+	"drawerToggleText": "Products",
 	"faithlifeStudyBibleLinkTitle": "Faithlife Study Bible",
 	"faithlifeStudyBibleLinkDescription": "Free, digital, and made for all translations",
 	"givingLinkTitle": "Faithlife Giving",

--- a/catalog/product-drawer/variations.md
+++ b/catalog/product-drawer/variations.md
@@ -11,5 +11,5 @@ showSource: true
 ```react
 showSource: true
 ---
-<ProductDrawerWithResources styleOverrides={{mobileTopOffset: '55px', toggleButtonColor: 'green', toggleButtonHoverColor: 'red', toggleTextColor: 'blue', toggleTextFontFamily: 'Arial', toggleTextFontSize: '16px' }} />
+<ProductDrawerWithResources title={"Tools"} styleOverrides={{mobileTopOffset: '55px', toggleButtonColor: 'green', toggleButtonHoverColor: 'red', toggleTextColor: 'blue', toggleTextFontFamily: 'Arial', toggleTextFontSize: '16px' }} />
 ```

--- a/catalog/product-drawer/variations.md
+++ b/catalog/product-drawer/variations.md
@@ -11,5 +11,5 @@ showSource: true
 ```react
 showSource: true
 ---
-<ProductDrawerWithResources title={"Tools"} styleOverrides={{mobileTopOffset: '55px', toggleButtonColor: 'green', toggleButtonHoverColor: 'red', toggleTextColor: 'blue', toggleTextFontFamily: 'Arial', toggleTextFontSize: '16px' }} />
+<ProductDrawerWithResources localizedResources={{drawerToggleText: 'Tools'}} styleOverrides={{mobileTopOffset: '55px', toggleButtonColor: 'green', toggleButtonHoverColor: 'red', toggleTextColor: 'blue', toggleTextFontFamily: 'Arial', toggleTextFontSize: '16px' }} />
 ```

--- a/components/product-drawer/component.jsx
+++ b/components/product-drawer/component.jsx
@@ -36,7 +36,7 @@ export class ProductDrawer extends React.PureComponent {
 			equipDescription: PropTypes.string.isRequired,
 			comingSoon: PropTypes.string.isRequired,
 			more: PropTypes.string.isRequired,
-			products: PropTypes.string.isRequired,
+			drawerToggleText: PropTypes.string.isRequired,
 			faithlifeStudyBibleLinkTitle: PropTypes.string.isRequired,
 			faithlifeStudyBibleLinkDescription: PropTypes.string.isRequired,
 			givingLinkTitle: PropTypes.string.isRequired,
@@ -90,7 +90,7 @@ export class ProductDrawer extends React.PureComponent {
 	};
 
 	render() {
-		const { styleOverrides, resources, title } = this.props;
+		const { styleOverrides, resources } = this.props;
 		const { isOpen } = this.state;
 
 		return (
@@ -117,7 +117,7 @@ export class ProductDrawer extends React.PureComponent {
 								/>
 							</svg>
 							<Styled.ProductDrawerToggleText styleOverrides={styleOverrides}>
-								{title || resources.products}
+								{resources.drawerToggleText}
 							</Styled.ProductDrawerToggleText>
 						</Styled.ProductDrawerToggle>
 					</PopoverReference>

--- a/components/product-drawer/component.jsx
+++ b/components/product-drawer/component.jsx
@@ -55,6 +55,7 @@ export class ProductDrawer extends React.PureComponent {
 			toggleTextFontFamily: PropTypes.string,
 			toggleTextFontSize: PropTypes.string,
 		}),
+		title: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -89,7 +90,7 @@ export class ProductDrawer extends React.PureComponent {
 	};
 
 	render() {
-		const { styleOverrides, resources } = this.props;
+		const { styleOverrides, resources, title } = this.props;
 		const { isOpen } = this.state;
 
 		return (
@@ -116,7 +117,7 @@ export class ProductDrawer extends React.PureComponent {
 								/>
 							</svg>
 							<Styled.ProductDrawerToggleText styleOverrides={styleOverrides}>
-								{resources.products}
+								{title || resources.products}
 							</Styled.ProductDrawerToggleText>
 						</Styled.ProductDrawerToggle>
 					</PopoverReference>


### PR DESCRIPTION
https://faithlife.atlassian.net/browse/FLCOM-3689

The Product Drawer is about to be added to Faithlife.com. We'd like to have the title be "Tools" instead of "Products" so I have added the ability to override the default title.