### PR TITLE
Demonstrate border-box issue in Switch component.

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -900,6 +900,13 @@ const pages = [
 		title: 'Switch',
 		content: pageLoader(() => import('./switch/variations.md')),
 		imports: {
+			GlobalBorderBox: styled.div`
+				*,
+				*:after,
+				*:before {
+					box-sizing: border-box;
+				}
+			`,
 			Switch,
 		},
 	},

--- a/catalog/switch/variations.md
+++ b/catalog/switch/variations.md
@@ -4,10 +4,12 @@
 showSource: true
 state: { isChecked: false }
 ---
+	<GlobalBorderBox>
 	<Switch
 		onClick={() => setState({ isChecked: !state.isChecked })}
 		isChecked={state.isChecked}
 	/>
+	</GlobalBorderBox>
 ```
 
 ### Binary choice
@@ -16,9 +18,11 @@ state: { isChecked: false }
 showSource: true
 state: { isChecked: false }
 ---
+	<GlobalBorderBox>
 	<Switch
 		variant="binaryChoice"
 		onClick={() => setState({ isChecked: !state.isChecked })}
 		isChecked={state.isChecked}
 	/>
+	</GlobalBorderBox>
 ```


### PR DESCRIPTION
Demo: https://deploy-preview-308--faithlife-styled-ui.netlify.com/#/Switch/variations

This PR demonstrates how the Switch component currently renders when the consuming environment has a global CSS style:

```css
*, :before, :after {
  box-sizing: border-box;
}
```

(such as on faithlife.com)

Here is the PR to fix it: https://github.com/Faithlife/styled-ui/pull/309