### PR TITLE
Set box-sizing on Switch :after element.

### DIFF
--- a/components/Switch.js
+++ b/components/Switch.js
@@ -52,6 +52,7 @@ export const Switch = styled(UtilityButton).attrs(({ isChecked }) => ({
 	position: relative;
 
 	&::after {
+		box-sizing: content-box !important;
 		width: var(--handle-width);
 		height: var(--handle-width);
 		border: solid;


### PR DESCRIPTION
This prevents an issue when the Switch component in an environment that
globally sets:

*, :before, *:after {
	box-sizing: border-box;
}

... such as faithlife.com

A demonstration of the issue is available here:
https://deploy-preview-308--faithlife-styled-ui.netlify.com/#/Switch/variations
https://github.com/Faithlife/styled-ui/pull/308