### PR TITLE
Make UtilityButton inherit font-family.

### DIFF
--- a/components/button/UtilityButton.js
+++ b/components/button/UtilityButton.js
@@ -3,6 +3,7 @@ import { box, typography } from '../../theme/system';
 import { theme } from '../../theme';
 
 const UtilityButton = styled.button`
+	font-family: inherit;
 	background: transparent;
 	border: none;
 	padding: 0;


### PR DESCRIPTION
- This makes it so consumers don't have to set this for every app in order to get their main font to show up by default.