### PR TITLE
export reactSelectComponents

### DIFF
--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -158,7 +158,7 @@ function handleKeyDown(e, onConsumerKeyDown) {
 	}
 }
 
-export reactSelectComponents;
+export { reactSelectComponents };
 
 /** Autocomplete control based on react-select */
 export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -158,6 +158,8 @@ function handleKeyDown(e, onConsumerKeyDown) {
 	}
 }
 
+export reactSelectComponents;
+
 /** Autocomplete control based on react-select */
 export const Select = React.forwardRef(({ components = {}, ...props }, ref) => {
 	const body = useBody();


### PR DESCRIPTION
Exports the reactSelectComponents so consumers can more easily, and more safely, customize the innards of react select.
Use case: I have a dropdown which has icons in it, and no way to insert them using vanilla reactSelect.
I can pass in custom `Option` and `Input` components, but I would have to make sure to style them and wire them up correctly. If I could instead wrap the native components, I could add the icons without having to rewrite internal behavior.
![image](https://user-images.githubusercontent.com/5589147/73095229-f71b4f00-3e96-11ea-8dc4-c67778cd300a.png)
