### PR TITLE
Add flag to control showing percentage text in tooltip

### DIFF
--- a/components/text-input-v2/inferred-base.jsx
+++ b/components/text-input-v2/inferred-base.jsx
@@ -67,6 +67,8 @@ export class InferredBase extends Component {
 	static propTypes = {
 		/** Decimal percent value for the confidence value. E.g. 0.75 */
 		confidence: PropTypes.number,
+		/** Show percentage text in tooltip.  Defaults to true. */
+		shouldShowPercentageText: PropTypes.bool,
 		/** String to display in the confidence tooltip. Defaults to Heuristic algorithm */
 		confidenceSource: PropTypes.string,
 		/** Function called when the OK button is clicked. Confidence should be set to null to clear the lightbulb indicator. */
@@ -79,10 +81,11 @@ export class InferredBase extends Component {
 
 	static defaultProps = {
 		confidenceSource: 'Heuristic Algorithm',
+		shouldShowPercentageText: true,
 	};
 
 	render() {
-		const { confidence, confidenceSource, onConfirm } = this.props;
+		const { confidence, shouldShowPercentageText, confidenceSource, onConfirm } = this.props;
 
 		const ConfidenceIcon =
 			confidence >= 0.9 ? (
@@ -96,7 +99,7 @@ export class InferredBase extends Component {
 		const tooltipContents = (
 			<TooltipContents>
 				<StyledParagraph>
-					{confidence && (
+					{confidence && !shouldShowPercentageText && (
 						<span>Value guessed with {Math.round(confidence * 100)}% confidence.</span>
 					)}
 					<span>Click OK if you can confirm value is correct, or delete or change the value.</span>

--- a/components/text-input-v2/inferred-select.jsx
+++ b/components/text-input-v2/inferred-select.jsx
@@ -13,6 +13,8 @@ export class InferredSelect extends Component {
 	static propTypes = {
 		/** Decimal percent value for the confidence value. E.g. 0.75 */
 		confidence: PropTypes.number,
+		/** Show percentage text in tooltip.  Defaults to true. */
+		shouldShowPercentageText: PropTypes.bool,
 		/** String to display in the confidence tooltip. Defaults to Heuristic algorithm */
 		confidenceSource: PropTypes.string,
 		/** Function called when the OK button is clicked. Confidence should be set to null to clear the lightbulb indicator. */
@@ -25,14 +27,23 @@ export class InferredSelect extends Component {
 
 	static defaultProps = {
 		confidenceSource: 'Heuristic Algorithm',
+		shouldShowPercentageText: true,
 	};
 
 	render() {
-		const { confidence, confidenceSource, className, onConfirm, renderSelect } = this.props;
+		const {
+			confidence,
+			shouldShowPercentageText,
+			confidenceSource,
+			className,
+			onConfirm,
+			renderSelect,
+		} = this.props;
 		return (
 			<InferredBase
 				className={className}
 				confidence={confidence}
+				shouldShowPercentageText={shouldShowPercentageText}
 				confidenceSource={confidenceSource}
 				onConfirm={onConfirm}
 			>

--- a/components/text-input-v2/inferred-text.jsx
+++ b/components/text-input-v2/inferred-text.jsx
@@ -19,6 +19,8 @@ export const InferredText = forwardClassRef(
 		static propTypes = {
 			/** Decimal percent value for the confidence value. E.g. 0.75 */
 			confidence: PropTypes.number,
+			/** Show percentage text in tooltip.  Defaults to true. */
+			shouldShowPercentageText: PropTypes.bool,
 			/** String to display in the confidence tooltip. Defaults to Heuristic algorithm */
 			confidenceSource: PropTypes.string,
 			/** Function called when the input is changed */
@@ -33,11 +35,13 @@ export const InferredText = forwardClassRef(
 
 		static defaultProps = {
 			confidenceSource: 'Heuristic Algorithm',
+			shouldShowPercentageText: true,
 		};
 
 		render() {
 			const {
 				confidence,
+				shouldShowPercentageText,
 				confidenceSource,
 				className,
 				onConfirm,
@@ -48,6 +52,7 @@ export const InferredText = forwardClassRef(
 				<InferredBase
 					className={className}
 					confidence={confidence}
+					shouldShowPercentageText={shouldShowPercentageText}
 					confidenceSource={confidenceSource}
 					onConfirm={onConfirm}
 				>

--- a/components/text-input/inferred-typeahead.jsx
+++ b/components/text-input/inferred-typeahead.jsx
@@ -26,6 +26,8 @@ export const InferredTypeahead = forwardClassRef(
 		static propTypes = {
 			/** Decimal percent value for the confidence value. E.g. 0.75 */
 			confidence: PropTypes.number,
+			/** Show percentage text in tooltip.  Defaults to true. */
+			shouldShowPercentageText: PropTypes.bool,
 			/** String to display in the confidence tooltip. Defaults to Heuristic algorithm */
 			confidenceSource: PropTypes.string,
 			/** Function called when the input value is changed */
@@ -38,11 +40,13 @@ export const InferredTypeahead = forwardClassRef(
 
 		static defaultProps = {
 			confidenceSource: 'Heuristic Algorithm',
+			shouldShowPercentageText: true,
 		};
 
 		render() {
 			const {
 				confidence,
+				shouldShowPercentageText,
 				confidenceSource,
 				className,
 				onConfirm,
@@ -56,6 +60,7 @@ export const InferredTypeahead = forwardClassRef(
 					<InferredBase
 						className={className}
 						confidence={confidence}
+						shouldShowPercentageText={shouldShowPercentageText}
 						confidenceSource={confidenceSource}
 						onConfirm={onConfirm}
 					>


### PR DESCRIPTION
There are cases where we are just interested in knowing if something is inferred or not.  In those cases we always pass 100% confidence and it is unnecessary to display the confidence sentence.