### PR TITLE
Allow conditionally hiding the circle on sequenced tabs.

### DIFF
--- a/components/tabs/tab.jsx
+++ b/components/tabs/tab.jsx
@@ -56,6 +56,7 @@ export function SequencedTab({
 	selected,
 	onSelectTab,
 	panelId,
+	hideCircle,
 	...props
 }) {
 	const tabRef = useRef();
@@ -77,9 +78,11 @@ export function SequencedTab({
 			selected={selected}
 			onClick={handleSelectTab}
 		>
-			<Styled.Circle selected={selected} completed={completed} disabled={disabled}>
-				{completed ? <SmallCheck /> : index + 1}
-			</Styled.Circle>
+			{!hideCircle && (
+				<Styled.Circle selected={selected} completed={completed} disabled={disabled}>
+					{completed ? <SmallCheck /> : index + 1}
+				</Styled.Circle>
+			)}
 			<Styled.SequencedTabContent
 				ref={tabRef}
 				disabled={disabled}


### PR DESCRIPTION
I need the styling form sequenced tabs, but don't need the numbers or check marks. The non-sequenced tabs have a totally different styling. So the options are 1. allow the other tabs to have the styling changed to look like this one or 2. allow hiding the circle from the sequenced ones.

https://app.zeplin.io/project/5d3b6ca65fc7e30e1d32a69c/screen/5e264cdc037cc36bc48c9b61