### PR TITLE
Use wrapper button in CalendarDate.

### DIFF
--- a/components/date-picker/calendar-date/component.jsx
+++ b/components/date-picker/calendar-date/component.jsx
@@ -25,16 +25,18 @@ export class CalendarDate extends Component {
 		this.props.dateFunctions.getMonth(date1) === this.props.dateFunctions.getMonth(date2) &&
 		this.props.dateFunctions.getYear(date1) === this.props.dateFunctions.getYear(date2);
 
-	renderCalendarWeekDay = (selectedDate, selectedDateRange, date, isCurrentMonth) => {
-		let CalendarWeekday = Styled.CalendarWeekDay;
-		const { isValid, isBefore } = this.props.dateFunctions;
+	getDayComponent = () => {
+		const isCurrentMonth = this.isCurrentMonth();
+		const { date, dateFunctions, selectedDate, selectedDateRange, validate } = this.props;
+		const { isValid, isBefore } = dateFunctions;
 
+		let CalendarWeekday = Styled.CalendarWeekDay;
 		if (selectedDate) {
 			if (selectedDate && isValid(selectedDate) && this.areDatesEqual(selectedDate, date)) {
 				CalendarWeekday = Styled.CalendarWeekDaySelected;
 			}
 
-			if (!isCurrentMonth || (this.props.validate && !this.props.validate(date))) {
+			if (!isCurrentMonth || (validate && !validate(date))) {
 				CalendarWeekday = Styled.CalendarWeekDayGrayedOut;
 			}
 			return CalendarWeekday;
@@ -53,43 +55,43 @@ export class CalendarDate extends Component {
 			CalendarWeekday = Styled.CalendarWeekDayInRange;
 		}
 
-		if (!isCurrentMonth || (this.props.validate && !this.props.validate(date))) {
+		if (!isCurrentMonth || (validate && !validate(date))) {
 			CalendarWeekday = Styled.CalendarWeekDayGrayedOut;
 		}
 
 		return CalendarWeekday;
 	};
 
+	isCurrentMonth = () => {
+		const { date, dateFunctions, currentMonth } = this.props;
+		return currentMonth === dateFunctions.getMonth(date);
+	};
+
 	render() {
 		const currentDate = new Date();
-		const { selectedDate, selectedDateRange, date, asDateRangePicker } = this.props;
+		const { date, asDateRangePicker } = this.props;
 		let currentDayDot = null;
-		const { format, getMonth } = this.props.dateFunctions;
+		const { format } = this.props.dateFunctions;
+		const isCurrentMonth = this.isCurrentMonth();
 
-		const isCurrentMonth = this.props.currentMonth === getMonth(date);
-
-		const CalendarWeekDay = this.renderCalendarWeekDay(
-			selectedDate,
-			selectedDateRange,
-			date,
-			isCurrentMonth,
-		);
+		const CalendarDay = this.getDayComponent();
 
 		if (this.areDatesEqual(currentDate, date)) {
 			currentDayDot = <Styled.CalendarWeekDayCurrentDay />;
 		}
 
 		return (
-			<CalendarWeekDay
+			<Styled.CalendarWeekDayButton
 				onClick={this.setSelectedDate}
-				tabIndex="-1"
 				disabled={this.props.validate && !this.props.validate(date)}
 			>
-				<Styled.CalendarDateLabel>
-					{asDateRangePicker && !isCurrentMonth ? null : format(date, 'd')}
-				</Styled.CalendarDateLabel>
-				{((asDateRangePicker && isCurrentMonth) || !asDateRangePicker) && currentDayDot}
-			</CalendarWeekDay>
+				<CalendarDay>
+					<Styled.CalendarDateLabel>
+						{asDateRangePicker && !isCurrentMonth ? null : format(date, 'd')}
+					</Styled.CalendarDateLabel>
+					{((asDateRangePicker && isCurrentMonth) || !asDateRangePicker) && currentDayDot}
+				</CalendarDay>
+			</Styled.CalendarWeekDayButton>
 		);
 	}
 }

--- a/components/date-picker/calendar-date/styled.jsx
+++ b/components/date-picker/calendar-date/styled.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { colors } from '../../shared-styles';
 
-const calendarWeekDayCss = `
+export const CalendarWeekDayButton = styled.button`
 	flex: 1;
 	position: relative;
 	box-sizing: border-box;
@@ -20,6 +20,11 @@ const calendarWeekDayCss = `
 		height: 44px;
 		width: 44px;
 	}
+`;
+
+const calendarWeekDayCss = `
+	width: 100%;
+	height: 100%;
 
 	&:hover {
 		background: ${colors.gray4};
@@ -40,7 +45,7 @@ export const CalendarWeekDay = styled.div`
 	${calendarWeekDayCss};
 `;
 
-export const CalendarWeekDaySelected = styled.button`
+export const CalendarWeekDaySelected = styled.div`
 	${calendarWeekDayCss}
 	background: ${colors.blueBase};
 	color: ${colors.white};
@@ -52,7 +57,7 @@ export const CalendarWeekDaySelected = styled.button`
 	}
 `;
 
-export const CalendarWeekDayInRange = styled.button`
+export const CalendarWeekDayInRange = styled.div`
 	${calendarWeekDayCss}
 	background: ${colors.blueTint};
 	border-radius: 0;


### PR DESCRIPTION
This PR fixes a bug where clicking any date in a date picker immediately closes the picker.

## Steps to reproduce
1. Go to https://faithlife.github.io/styled-ui/#/date-picker/variations
2. Under "Default Date Range Picker," click "Select Dates."
3. Click a day in the miniature calendar.
    * Expected: The picker should remain open so I can choose an end date.
    * Actual: The picker immediately closes.

## Problem and solution
There's a little bit of an anti-pattern here where we're styling an HTML `button` element by swapping out different components that render it. This leads to [DOM node destruction](https://reactjs.org/docs/reconciliation.html#elements-of-different-types) on button clicks. In our case, we're replacing a `CalendarWeekDay` with a `CalendarWeekDaySelected` on click. Soon afterward, [we check to see if the element clicked is a child of the popup](https://github.com/Faithlife/styled-ui/blob/85b271bd0f1d23e92f757c49fe543f46d154174a/components/shared-hooks/use-focus-away-handler.js#L18) to decide whether we should close the popup. That logic is written with the assumption that that the element that received focus is still in the DOM.

This is also not a preferred pattern for accessibility reasons: Tab key navigation does not work as expected when you're removing the focused element on "click."

To solve the above problems, this PR uses a very plain-looking button and instead swaps out its children to make the button appear how it should.