### PR TITLE
Remove old theme providers

### DIFF
--- a/components/check-box/checkbox-content.jsx
+++ b/components/check-box/checkbox-content.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styled from './styled';
 
-export function CheckboxContent({ isChecked, title, children, disabled }) {
+export function CheckboxContent({ isChecked, title, children, disabled, theme }) {
 	return (
 		<React.Fragment>
-			<Styled.CheckboxDiv disabled={disabled}>
-				<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} />
+			<Styled.CheckboxDiv disabled={disabled} theme={theme}>
+				<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} theme={theme} />
 			</Styled.CheckboxDiv>
 			{title && <Styled.Label>{title}</Styled.Label>}
 			{children && <Styled.Label>{children}</Styled.Label>}

--- a/components/check-box/component.jsx
+++ b/components/check-box/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider } from 'styled-components';
 import { colors as sharedColors } from '../shared-styles';
 import { CheckboxContent } from './checkbox-content';
 import * as Styled from './styled';
@@ -44,22 +43,21 @@ export class Checkbox extends Component {
 	render() {
 		const { onClick, title, isChecked, theme, type, children, className, disabled } = this.props;
 		return (
-			<ThemeProvider theme={theme}>
-				<Styled.CheckboxContainer
-					ref={this.componentRef}
-					onClick={onClick}
-					onMouseUp={this.onMouseUp}
-					type={type}
-					className={className}
-					role={'checkbox'}
-					aria-checked={isChecked}
-					disabled={disabled}
-				>
-					<CheckboxContent isChecked={isChecked} title={title} disabled={disabled}>
-						{children}
-					</CheckboxContent>
-				</Styled.CheckboxContainer>
-			</ThemeProvider>
+			<Styled.CheckboxContainer
+				ref={this.componentRef}
+				onClick={onClick}
+				onMouseUp={this.onMouseUp}
+				type={type}
+				className={className}
+				role={'checkbox'}
+				aria-checked={isChecked}
+				disabled={disabled}
+				theme={theme}
+			>
+				<CheckboxContent isChecked={isChecked} title={title} disabled={disabled} theme={theme}>
+					{children}
+				</CheckboxContent>
+			</Styled.CheckboxContainer>
 		);
 	}
 }

--- a/components/dropdown/dropdown-children/menu-checkbox.jsx
+++ b/components/dropdown/dropdown-children/menu-checkbox.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider } from 'styled-components';
 import { CheckboxContent } from '../../check-box';
 import { useDropdownContext } from '../dropdown-utils';
 import * as Styled from '../styled';
@@ -25,9 +24,11 @@ export function MenuCheckbox(props) {
 			role="menuitemcheckbox"
 			aria-checked={isChecked}
 		>
-			<ThemeProvider theme={{ primary: theme.checkboxPrimary, border: theme.checkboxBorder }}>
-				<CheckboxContent isChecked={isChecked} {...checkboxProps} />
-			</ThemeProvider>
+			<CheckboxContent
+				theme={{ primary: theme.checkboxPrimary, border: theme.checkboxBorder }}
+				isChecked={isChecked}
+				{...checkboxProps}
+			/>
 		</MenuItem>
 	);
 }

--- a/components/radio/component.jsx
+++ b/components/radio/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider } from 'styled-components';
 import { colors as sharedColors } from '../shared-styles';
 import * as Styled from './styled';
 
@@ -52,24 +51,23 @@ export class Radio extends Component {
 	render() {
 		const { onClick, title, isChecked, theme, type, children, className, disabled } = this.props;
 		return (
-			<ThemeProvider theme={theme}>
-				<Styled.RadioContainer
-					ref={this.componentRef}
-					onMouseUp={this.onMouseUp}
-					onClick={onClick}
-					type={type}
-					className={className}
-					role={'radio'}
-					aria-checked={isChecked}
-					disabled={disabled}
-				>
-					<Styled.RadioDiv disabled={disabled}>
-						<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} />
-					</Styled.RadioDiv>
-					{title && <Styled.Label>{title}</Styled.Label>}
-					{children && <Styled.Label>{children}</Styled.Label>}
-				</Styled.RadioContainer>
-			</ThemeProvider>
+			<Styled.RadioContainer
+				ref={this.componentRef}
+				onMouseUp={this.onMouseUp}
+				onClick={onClick}
+				type={type}
+				className={className}
+				role={'radio'}
+				aria-checked={isChecked}
+				disabled={disabled}
+				theme={theme}
+			>
+				<Styled.RadioDiv disabled={disabled} theme={theme}>
+					<Styled.CheckedIndicator isChecked={isChecked} disabled={disabled} theme={theme} />
+				</Styled.RadioDiv>
+				{title && <Styled.Label>{title}</Styled.Label>}
+				{children && <Styled.Label>{children}</Styled.Label>}
+			</Styled.RadioContainer>
 		);
 	}
 }


### PR DESCRIPTION
These components deserve a port to styled-system, but this is a quick attempt to allow *children* of these Checkbox/Radio components to benefit from the styled-system theme in a backwards-compatible way in the meantime.