### PR TITLE
Use relative values for the check indicator

### DIFF
--- a/components/radio/styled.jsx
+++ b/components/radio/styled.jsx
@@ -7,6 +7,7 @@ export const RadioDiv = styled.div`
 	border-radius: 14px;
 	width: 14px;
 	height: 14px;
+	padding: 2px;
 	background: transparent;
 
 	${props =>
@@ -60,24 +61,17 @@ opacity: 1;
 }`;
 
 export const CheckedIndicator = styled.div`
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 14px;
-	height: 14px;
+	display: flex;
+	height: 100%;
 	cursor: pointer;
 
 	${props => (props.disabled ? 'cursor: default;' : '')};
 
 	&:after {
+		flex: 1;
 		background: ${props => props.theme.primary};
 		content: '';
-		position: absolute;
-		top: 2px;
-		left: 2px;
-		border-radius: 8px;
-		height: 8px;
-		width: 8px;
+		border-radius: 50%;
 		opacity: 0;
 	}
 


### PR DESCRIPTION
The absolute positioning of the indicator resulted in misalignment under some browsers and conditions:

![image](https://user-images.githubusercontent.com/2214238/79808891-f7a37480-8323-11ea-8403-6229cf8513ca.png)

The use of flex and padding allows the size of the check indicator to consistently fill the space within the radio button.