### PR TITLE
Restore tablist variant styles.

### DIFF
--- a/components/tabs/tab-helpers.jsx
+++ b/components/tabs/tab-helpers.jsx
@@ -9,7 +9,7 @@ export function TabList({ children }) {
 
 	const handleKeyboardNav = useKeyboardNav(selectedTabIndex, onSelectTab, children);
 	return (
-		<Styled.TabListCore onKeyDown={handleKeyboardNav}>
+		<Styled.TabListCore onKeyDown={handleKeyboardNav} variant={variant}>
 			{React.Children.map(children, (child, index) =>
 				React.isValidElement(child)
 					? React.cloneElement(child, {


### PR DESCRIPTION
The variant prop was unintentionally removed between PRs during a rebase, this restores their styles, most notably the 4px margin spacing between tabs.