### PR TITLE
Add popover v6 implementation

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -79,6 +79,7 @@ import { PopulationChange } from './grid/population-change';
 import { IncrementButton } from './grid/cell-editors';
 import { BaseGrid } from '../components/grid/base-grid';
 import { SimpleGrid, GridColumn, PaginatedGrid, TreeGrid } from '../components/grid';
+import { Popover as PopoverV6 } from '../components/popover-v6';
 import { IconGroup } from './icon-table';
 import { FavoriteFilled } from '../components/icons/18px';
 import { ChevronDown } from '../components/icons/12px';
@@ -746,10 +747,39 @@ const pages = [
 				},
 			},
 			{
+				path: '/popover/vatiations-v6',
+				title: 'Popover Variations v6',
+				content: pageLoader(() => import('./popover/variations-v6.md')),
+				imports: {
+					Button,
+					Popover: PopoverV6,
+					PopoverDemo: styled.div`
+						display: flex;
+						align-items: flex-start;
+						justify-content: space-between;
+					`,
+					PopoverOverflowDemo: styled.div`
+						display: flex;
+						align-items: flex-start;
+						justify-content: space-around;
+						position: relative;
+						overflow: hidden;
+						padding-top: 20px;
+					`,
+					refs: new Array(10).fill(0).map(React.createRef),
+				},
+			},
+			{
 				path: '/popover/documentation',
 				title: 'Popover Documentation',
 				content: pageLoader(() => import('./popover/documentation.md')),
 				imports: { Popover, PopoverBase, DocgenTable, Tooltip, PopoverManager },
+			},
+			{
+				path: '/popover/documentation-v6',
+				title: 'Popover Documentation v6',
+				content: pageLoader(() => import('./popover/documentation-v6.md')),
+				imports: { Popover: PopoverV6, DocgenTable },
 			},
 		],
 	},

--- a/catalog/popover/documentation-v6.md
+++ b/catalog/popover/documentation-v6.md
@@ -1,0 +1,10 @@
+This documentation is automatically generated from jsdoc comments.
+
+`usePopover`: function(reference, options);
+see https://popper.js.org/docs/v2/ for more detailed documentation
+
+```react
+noSource: true
+---
+<DocgenTable component={Popover} displayName={'Popover props'} />
+```

--- a/catalog/popover/variations-v6.md
+++ b/catalog/popover/variations-v6.md
@@ -22,38 +22,38 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2: false, isOpen3: false, isOpen4: false }
 ---
 <PopoverDemo>
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[1]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })} ref={refs[1]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
-		<Popover reference={refs[1].current} placement="top" onFocusAway={() => setState({ isOpen: false })}>
+	{state.isOpen1 && (
+		<Popover reference={refs[1].current} placement="top" onFocusAway={() => setState({ isOpen1: false })}>
 			Hello!
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[2]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })} ref={refs[2]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
-		<Popover reference={refs[2].current} placement="bottom" onFocusAway={() => setState({ isOpen: false })}>
+	{state.isOpen2 && (
+		<Popover reference={refs[2].current} placement="bottom" onFocusAway={() => setState({ isOpen2: false })}>
 			Hello!
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[3]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen3: !state.isOpen3 })} ref={refs[3]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
-		<Popover reference={refs[3].current} placement="left" onFocusAway={() => setState({ isOpen: false })}>
+	{state.isOpen3 && (
+		<Popover reference={refs[3].current} placement="left" onFocusAway={() => setState({ isOpen3: false })}>
 			Hello!
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[4]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen4: !state.isOpen4 })} ref={refs[4]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
-		<Popover reference={refs[4].current} placement="right" onFocusAway={() => setState({ isOpen: false })}>
+	{state.isOpen4 && (
+		<Popover reference={refs[4].current} placement="right" onFocusAway={() => setState({ isOpen4: false })}>
 			Hello!
 		</Popover>
 	)}
@@ -64,30 +64,30 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2: false, isOpen3: false }
 ---
 <PopoverDemo>
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[5]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })} ref={refs[5]}>
 		Show a blue Popover!
 	</Button>
-	{state.isOpen && (
+	{state.isOpen1 && (
 		<Popover
 			reference={refs[5].current}
 			placement="top"
-			onFocusAway={() => setState({ isOpen: false })}
+			onFocusAway={() => setState({ isOpen1: false })}
 			backgroundColor="#ebf7ff"
 		>
 			Hello!
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[6]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })} ref={refs[6]}>
 		Show a Popover with multiple custom styles!
 	</Button>
-	{state.isOpen && (
+	{state.isOpen2 && (
 		<Popover
 			reference={refs[6].current}
 			placement="top"
-			onFocusAway={() => setState({ isOpen: false })}
+			onFocusAway={() => setState({ isOpen2: false })}
 			boxShadow=""
 			padding="18px"
 			width="200px"
@@ -97,14 +97,14 @@ state: { isOpen: false }
 			Hello!
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[7]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen3: !state.isOpen3 })} ref={refs[7]}>
 		Show a Popover without an arrow!
 	</Button>
-	{state.isOpen && (
+	{state.isOpen3 && (
 		<Popover
 			reference={refs[7].current}
 			placement="top"
-			onFocusAway={() => setState({ isOpen: false })}
+			onFocusAway={() => setState({ isOpen3: false })}
 			hideArrow
 		>
 			Hello!
@@ -117,27 +117,27 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2 }
 ---
 // overflow: hidden
 <PopoverOverflowDemo>
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[8]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })} ref={refs[8]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
-		<Popover reference={refs[8].current} placement="top" onFocusAway={() => setState({ isOpen: false })}>
+	{state.isOpen1 && (
+		<Popover reference={refs[8].current} placement="top" onFocusAway={() => setState({ isOpen1: false })}>
 			I'm inline
 		</Popover>
 	)}
-	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[9]}>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })} ref={refs[9]}>
 		Show a Popover!
 	</Button>
-	{state.isOpen && (
+	{state.isOpen2 && (
 		<Popover
 			reference={refs[9].current}
 			placement="top"
 			container="body"
-			onFocusAway={() => setState({ isOpen: false })}
+			onFocusAway={() => setState({ isOpen2: false })}
 		>
 			I'm thinking with portals!
 		</Popover>

--- a/catalog/popover/variations-v6.md
+++ b/catalog/popover/variations-v6.md
@@ -1,0 +1,146 @@
+## Popover v6
+
+onFocusAway should always be used according to the spec.
+
+```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverDemo>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[0]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[0].current} placement="top" onFocusAway={() => setState({ isOpen: false })}>
+			Hello!
+		</Popover>
+	)}
+</PopoverDemo>
+```
+
+## Placement
+
+```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverDemo>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[1]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[1].current} placement="top" onFocusAway={() => setState({ isOpen: false })}>
+			Hello!
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[2]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[2].current} placement="bottom" onFocusAway={() => setState({ isOpen: false })}>
+			Hello!
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[3]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[3].current} placement="left" onFocusAway={() => setState({ isOpen: false })}>
+			Hello!
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[4]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[4].current} placement="right" onFocusAway={() => setState({ isOpen: false })}>
+			Hello!
+		</Popover>
+	)}
+</PopoverDemo>
+```
+
+## Options
+
+```react
+showSource: true
+state: { isOpen: false }
+---
+<PopoverDemo>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[5]}>
+		Show a blue Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover
+			reference={refs[5].current}
+			placement="top"
+			onFocusAway={() => setState({ isOpen: false })}
+			backgroundColor="#ebf7ff"
+		>
+			Hello!
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[6]}>
+		Show a Popover with multiple custom styles!
+	</Button>
+	{state.isOpen && (
+		<Popover
+			reference={refs[6].current}
+			placement="top"
+			onFocusAway={() => setState({ isOpen: false })}
+			boxShadow=""
+			padding="18px"
+			width="200px"
+			border="black solid 1px"
+			zIndex={10}
+		>
+			Hello!
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[7]}>
+		Show a Popover without an arrow!
+	</Button>
+	{state.isOpen && (
+		<Popover
+			reference={refs[7].current}
+			placement="top"
+			onFocusAway={() => setState({ isOpen: false })}
+			hideArrow
+		>
+			Hello!
+		</Popover>
+	)}
+</PopoverDemo>
+```
+
+## Using container prop
+
+```react
+showSource: true
+state: { isOpen: false }
+---
+// overflow: hidden
+<PopoverOverflowDemo>
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[8]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover reference={refs[8].current} placement="top" onFocusAway={() => setState({ isOpen: false })}>
+			I'm inline
+		</Popover>
+	)}
+	<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} ref={refs[9]}>
+		Show a Popover!
+	</Button>
+	{state.isOpen && (
+		<Popover
+			reference={refs[9].current}
+			placement="top"
+			container="body"
+			onFocusAway={() => setState({ isOpen: false })}
+		>
+			I'm thinking with portals!
+		</Popover>
+	)}
+</PopoverOverflowDemo>
+```

--- a/catalog/popover/variations.md
+++ b/catalog/popover/variations.md
@@ -44,46 +44,46 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2: false, isOpen3: false, isOpen4: false }
 ---
 <PopoverDemo>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen1: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top">
+		<Popover isOpen={state.isOpen1} placement="top">
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen2: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="bottom">
+		<Popover isOpen={state.isOpen2} placement="bottom">
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen3: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen3: !state.isOpen3 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="left">
+		<Popover isOpen={state.isOpen3} placement="left">
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen4: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen4: !state.isOpen4 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="right">
+		<Popover isOpen={state.isOpen4} placement="right">
 			Hello!
 		</Popover>
 	</PopoverManager>
@@ -94,27 +94,27 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2: false, isOpen3: false, isOpen4: false }
 ---
 <PopoverDemo>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen1: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" theme={{ backgroundColor: '#ebf7ff' }}>
+		<Popover isOpen={state.isOpen1} placement="top" theme={{ backgroundColor: '#ebf7ff' }}>
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen2: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })}>
 				Show a Popover with zIndex!
 			</Button>
 		</PopoverReference>
 		<Popover
-			isOpen={state.isOpen}
+			isOpen={state.isOpen2}
 			placement="top"
 			styleOverrides={{
 				padding: '18px',
@@ -127,23 +127,23 @@ state: { isOpen: false }
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen3: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen3: !state.isOpen3 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" hideArrow>
+		<Popover isOpen={state.isOpen3} placement="top" hideArrow>
 			Hello!
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen4: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen4: !state.isOpen4 })}>
 				Show a Popover w/ a delay!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" delay={{ show: 1000, hide: 1000 }}>
+		<Popover isOpen={state.isOpen4} placement="top" delay={{ show: 1000, hide: 1000 }}>
 			Hello!
 		</Popover>
 	</PopoverManager>
@@ -154,27 +154,27 @@ state: { isOpen: false }
 
 ```react
 showSource: true
-state: { isOpen: false }
+state: { isOpen1: false, isOpen2: false }
 ---
 // overflow: hidden
 <PopoverOverflowDemo>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen1: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen1: !state.isOpen1 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top">
+		<Popover isOpen={state.isOpen1} placement="top">
 			I'm inline
 		</Popover>
 	</PopoverManager>
-	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+	<PopoverManager onFocusAway={() => setState({ isOpen2: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen2: !state.isOpen2 })}>
 				Show a Popover!
 			</Button>
 		</PopoverReference>
-		<Popover isOpen={state.isOpen} placement="top" container="body">
+		<Popover isOpen={state.isOpen2} placement="top" container="body">
 			I'm thinking with portals!
 		</Popover>
 	</PopoverManager>

--- a/components/popover-v6/index.jsx
+++ b/components/popover-v6/index.jsx
@@ -1,0 +1,113 @@
+/* eslint eqeqeq: ["error", "always", {"null": "never"}] */
+import React, { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { usePopper } from 'react-popper';
+import { PopoverContainer, PopoverArrow } from './styled';
+
+export function usePopover(reference, options) {
+	const [popperElement, setPopper] = useState();
+	const [arrowElement, setArrow] = useState();
+	const { styles, attributes, ...rest } = usePopper(reference, popperElement, {
+		...options,
+		modifiers: [
+			...(options?.modifiers ?? []),
+			{ name: 'arrow', options: { element: arrowElement } },
+		],
+	});
+
+	return {
+		popperElement,
+		popperProps: { ...attributes.popper, style: styles.popper, ref: setPopper },
+		arrowProps: { ...attributes.arrow, style: styles.arrow, ref: setArrow },
+		...rest,
+	};
+}
+
+const arrowOffset = { name: 'offset', options: { offset: [0, 10] } };
+export function Popover({
+	reference,
+	placement,
+	modifiers,
+	strategy,
+	container,
+	hideArrow,
+	onFocusAway,
+	children,
+	...restProps
+}) {
+	const { popperElement, popperProps, arrowProps } = usePopover(reference, {
+		placement,
+		modifiers: hideArrow ? modifiers : [arrowOffset].concat(modifiers ?? []),
+		strategy,
+	});
+
+	useEffect(() => {
+		if (popperElement != null && onFocusAway instanceof Function) {
+			const onClick = event => {
+				if (!popperElement.contains(event.target)) {
+					onFocusAway();
+				}
+			};
+
+			document.addEventListener('click', onClick);
+			return () => document.removeEventListener('click', onClick);
+		}
+	}, [onFocusAway, popperElement]);
+
+	const popover = (
+		<PopoverContainer {...restProps} {...popperProps}>
+			{children}
+			{!hideArrow && <PopoverArrow {...arrowProps} />}
+		</PopoverContainer>
+	);
+
+	if (container != null) {
+		return ReactDOM.createPortal(popover, container === 'body' ? document.body : container.current);
+	}
+
+	return popover;
+}
+
+Popover.propTypes = {
+	/** the element or virtual element to anchor to */
+	reference: PropTypes.oneOfType([
+		PropTypes.element,
+		PropTypes.shape({
+			getBoundingClientRect: PropTypes.func.isRequired,
+			contextElement: PropTypes.element,
+		}),
+	]),
+	/** where on the target the popover anchors */
+	placement: PropTypes.oneOf([
+		'auto',
+		'auto-start',
+		'auto-end',
+		'top',
+		'top-start',
+		'top-end',
+		'bottom',
+		'bottom-start',
+		'bottom-end',
+		'right',
+		'right-start',
+		'right-end',
+		'left',
+		'left-start',
+		'left-end',
+	]),
+	/** modifiers allow custom behavior, see https://popper.js.org/docs/v2/modifiers */
+	modifiers: PropTypes.arrayOf(
+		PropTypes.shape({
+			name: PropTypes.string.isRequired,
+		}),
+	),
+	/** whether popover should use absolute or fixed positioning */
+	strategy: PropTypes.oneOf(['absolute', 'fixed']),
+	/** where to inject the popover, defaults to inline */
+	container: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+	/** whether or not to show the arrow */
+	hideArrow: PropTypes.bool,
+	/** handler useful for closing popover when clicking away */
+	onFocusAway: PropTypes.func,
+};

--- a/components/popover-v6/index.jsx
+++ b/components/popover-v6/index.jsx
@@ -1,4 +1,3 @@
-/* eslint eqeqeq: ["error", "always", {"null": "never"}] */
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
@@ -52,7 +51,7 @@ export function Popover({
 		</PopoverContainer>
 	);
 
-	if (container != null) {
+	if (container !== null && container !== undefined) {
 		return ReactDOM.createPortal(popover, container === 'body' ? document.body : container.current);
 	}
 

--- a/components/popover-v6/styled.js
+++ b/components/popover-v6/styled.js
@@ -27,6 +27,7 @@ export const PopoverContainer = styled(Box)`
 	background-color: ${({ backgroundColor, theme }) =>
 		backgroundColor ?? theme.colors.popover.background};
 	z-index: ${({ zIndex, theme }) => zIndex || theme.zIndices.menu};
+	outline: none !important;
 
 	& > ${PopoverArrow}::after {
 		border: ${({ border }) => border ?? 'none'};

--- a/components/popover-v6/styled.js
+++ b/components/popover-v6/styled.js
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+import { Box } from '../Box';
+
+export const PopoverArrow = styled(Box)`
+	position: absolute;
+	width: 25px;
+	height: 25px;
+	pointer-events: none;
+	overflow: hidden;
+
+	&::after {
+		content: '';
+		position: absolute;
+		transform: translate(-50%, -50%) rotate(45deg);
+		box-shadow: ${({ theme }) => theme.shadows[1]};
+		width: 10px;
+		height: 10px;
+		background-color: white;
+	}
+`;
+
+export const PopoverContainer = styled(Box)`
+	position: absolute;
+	box-shadow: ${({ boxShadow, theme }) => boxShadow ?? theme.shadows[1]};
+	border-radius: ${({ borderRadius, theme }) => borderRadius ?? theme.radii[1]};
+	padding: ${({ padding }) => padding ?? '12px'};
+	background-color: ${({ backgroundColor, theme }) =>
+		backgroundColor ?? theme.colors.popover.background};
+	z-index: ${({ zIndex, theme }) => zIndex || theme.zIndices.menu};
+
+	& > ${PopoverArrow}::after {
+		border: ${({ border }) => border ?? 'none'};
+		box-shadow: ${({ boxShadow, theme }) => boxShadow ?? theme.shadows[1]};
+		background-color: ${({ backgroundColor, theme }) =>
+			backgroundColor ?? theme.colors.popover.background};
+	}
+
+	&[data-popper-placement^='top'] > ${PopoverArrow} {
+		top: 100%;
+
+		&:after {
+			top: 0;
+			left: 50%;
+		}
+	}
+
+	&[data-popper-placement^='bottom'] > ${PopoverArrow} {
+		bottom: 100%;
+
+		&:after {
+			top: 100%;
+			left: 50%;
+		}
+	}
+
+	&[data-popper-placement^='left'] > ${PopoverArrow} {
+		left: 100%;
+
+		&:after {
+			left: 0;
+			top: 50%;
+		}
+	}
+
+	&[data-popper-placement^='right'] > ${PopoverArrow} {
+		right: 100%;
+
+		&:after {
+			left: 100%;
+			top: 50%;
+		}
+	}
+`;

--- a/components/popover/popover-base.jsx
+++ b/components/popover/popover-base.jsx
@@ -3,10 +3,11 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 import { deprecate } from '../utils/deprecate';
+import { mergeRefs } from '../utils/merge-refs';
 import { Box } from '../Box';
 import {
+	PopoverContext,
 	PlacementOptionsProps,
-	FocusHandlerInboundsElement,
 	arrowWidth,
 	maxWidth,
 	maxHeight,
@@ -71,6 +72,8 @@ export class PopoverBase extends Component {
 		modifiers: [],
 		styleOverrides: {},
 	};
+
+	static contextType = PopoverContext;
 
 	state = {
 		showPopper: this.props.isOpen || false,
@@ -158,7 +161,7 @@ export class PopoverBase extends Component {
 			>
 				{({ ref, style, placement, arrowProps }) => (
 					<Box
-						ref={ref}
+						ref={mergeRefs(ref, this.context.targetRef)}
 						placement={placement}
 						style={{
 							...style,
@@ -189,8 +192,10 @@ export class PopoverBase extends Component {
 						zIndex={styleOverrides.zIndex ?? 'menu'}
 						css={`
 							text-align: ${styleOverrides.textAlign ?? 'left'};
+							outline: none !important;
 							${styleOverrides.overflow ? `overflow: ${styleOverrides.overflow}` : ''};
 						`}
+						tabIndex="-1"
 						{...props}
 					>
 						{children}
@@ -228,10 +233,7 @@ export class PopoverBase extends Component {
 		);
 
 		if (!!this.targetContainer && showPopper) {
-			return ReactDOM.createPortal(
-				<FocusHandlerInboundsElement>{popover}</FocusHandlerInboundsElement>,
-				this.targetContainer,
-			);
+			return ReactDOM.createPortal(popover, this.targetContainer);
 		}
 
 		if (showPopper) {

--- a/components/popover/popover-base.jsx
+++ b/components/popover/popover-base.jsx
@@ -1,10 +1,11 @@
-import React, { Component } from 'react';
+import React, { Component, useContext } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 import { deprecate } from '../utils/deprecate';
 import { mergeRefs } from '../utils/merge-refs';
 import { Box } from '../Box';
+import { useFocusAwayHandler } from '../shared-hooks';
 import {
 	PopoverContext,
 	PlacementOptionsProps,
@@ -73,8 +74,6 @@ export class PopoverBase extends Component {
 		styleOverrides: {},
 	};
 
-	static contextType = PopoverContext;
-
 	state = {
 		showPopper: this.props.isOpen || false,
 	};
@@ -129,117 +128,121 @@ export class PopoverBase extends Component {
 	};
 
 	render() {
-		const {
-			children,
-			placement: popoverPlacement,
-			hideArrow,
-			delay,
-			theme,
-			modifiers,
-			styleOverrides,
-			eventsEnabled,
-			positionFixed,
-			...props
-		} = this.props;
 		const { showPopper } = this.state;
 
-		const popperModifiers = [];
-		if (modifiers instanceof Array) {
-			popperModifiers.push(...modifiers);
-		} else {
-			deprecate(
-				'v1 style modifiers detected, please update to v2: https://popper.js.org/docs/v2/modifiers/',
-			);
-		}
-		popperModifiers.push({ name: 'computeStyle', options: { gpuAcceleration: false } });
-
-		const popover = (
-			<Popper
-				placement={popoverPlacement}
-				modifiers={popperModifiers}
-				strategy={positionFixed ? 'fixed' : 'absolute'}
-			>
-				{({ ref, style, placement, arrowProps }) => (
-					<Box
-						ref={mergeRefs(ref, this.context.targetRef)}
-						placement={placement}
-						style={{
-							...style,
-							...(!hideArrow ? margins[getPlacement(placement)] : {}),
-						}}
-						delay={delay}
-						onAnimationEnd={this.handleTransition}
-						hideArrow={hideArrow}
-						backgroundColor={theme?.backgroundColor ?? 'popover.background'}
-						border={styleOverrides.border ?? 'none'}
-						borderRadius={styleOverrides.borderRadius ?? 0}
-						boxShadow={styleOverrides.hideShadow ? 0 : 1}
-						color={theme?.textColor ?? ''}
-						fontSize={styleOverrides.fontSize ?? 'medium'}
-						fontWeight={styleOverrides.fontWeight ?? 'normal'}
-						height={styleOverrides.height ?? 'auto'}
-						lineHeight={styleOverrides.lineHeight ?? 'normal'}
-						margin={styleOverrides.margin ?? 0}
-						maxHeight={styleOverrides.maxHeight ?? maxHeight}
-						maxWidth={styleOverrides.maxWidth ?? maxWidth}
-						minHeight={styleOverrides.minHeight ?? ''}
-						minWidth={styleOverrides.minWidth ?? ''}
-						outline={styleOverrides.outline ?? ''}
-						padding={styleOverrides.padding ?? 0}
-						position="absolute"
-						whiteSpace="normal"
-						width={styleOverrides.width ?? 'auto'}
-						zIndex={styleOverrides.zIndex ?? 'menu'}
-						css={`
-							text-align: ${styleOverrides.textAlign ?? 'left'};
-							outline: none !important;
-							${styleOverrides.overflow ? `overflow: ${styleOverrides.overflow}` : ''};
-						`}
-						tabIndex="-1"
-						{...props}
-					>
-						{children}
-						{!hideArrow && (
-							<Box
-								ref={arrowProps.ref}
-								style={arrowProps.style}
-								css={`
-									width: 25px;
-									height: 25px;
-									position: absolute;
-									overflow: hidden;
-									pointer-events: none;
-									text-align: center;
-									--bg: ${({ theme }) => theme.colors.popover.background};
-									--shadow: ${({ theme }) => theme.shadows[1]};
-
-									&::after {
-										content: '';
-										border: ${styleOverrides?.border ?? 'none'};
-										position: absolute;
-										width: ${arrowWidth};
-										height: ${arrowWidth};
-										background: ${theme?.backgroundColor ?? 'var(--bg)'};
-										transform: translateX(-50%) translateY(-50%) rotate(45deg);
-										box-shadow: ${styleOverrides?.hideShadow ? 'none' : 'var(--shadow)'};
-									}
-									${placement ? arrowStyles[getPlacement(placement)] : arrowStyles.top};
-								`}
-							/>
-						)}
-					</Box>
-				)}
-			</Popper>
-		);
-
 		if (!!this.targetContainer && showPopper) {
-			return ReactDOM.createPortal(popover, this.targetContainer);
+			return ReactDOM.createPortal(<PopoverCore {...this.props} />, this.targetContainer);
 		}
 
 		if (showPopper) {
-			return popover;
+			return <PopoverCore {...this.props} />;
 		}
 
 		return null;
 	}
+}
+
+function PopoverCore({
+	children,
+	placement: popoverPlacement,
+	hideArrow,
+	delay,
+	theme,
+	modifiers,
+	styleOverrides,
+	eventsEnabled,
+	positionFixed,
+	...rest
+}) {
+	const { onFocusAway } = useContext(PopoverContext);
+	const focusRef = useFocusAwayHandler(onFocusAway);
+
+	const popperModifiers = [];
+	if (modifiers instanceof Array) {
+		popperModifiers.push(...modifiers);
+	} else {
+		deprecate(
+			'v1 style modifiers detected, please update to v2: https://popper.js.org/docs/v2/modifiers/',
+		);
+	}
+
+	popperModifiers.push({ name: 'computeStyle', options: { gpuAcceleration: false } });
+
+	return (
+		<Popper
+			placement={popoverPlacement}
+			modifiers={popperModifiers}
+			strategy={positionFixed ? 'fixed' : 'absolute'}
+		>
+			{({ ref, style, placement, arrowProps }) => (
+				<Box
+					ref={mergeRefs(ref, focusRef)}
+					placement={placement}
+					style={{
+						...style,
+						...(!hideArrow ? margins[getPlacement(placement)] : {}),
+					}}
+					delay={delay}
+					hideArrow={hideArrow}
+					backgroundColor={theme?.backgroundColor ?? 'popover.background'}
+					border={styleOverrides.border ?? 'none'}
+					borderRadius={styleOverrides.borderRadius ?? 0}
+					boxShadow={styleOverrides.hideShadow ? 0 : 1}
+					color={theme?.textColor ?? ''}
+					fontSize={styleOverrides.fontSize ?? 'medium'}
+					fontWeight={styleOverrides.fontWeight ?? 'normal'}
+					height={styleOverrides.height ?? 'auto'}
+					lineHeight={styleOverrides.lineHeight ?? 'normal'}
+					margin={styleOverrides.margin ?? 0}
+					maxHeight={styleOverrides.maxHeight ?? maxHeight}
+					maxWidth={styleOverrides.maxWidth ?? maxWidth}
+					minHeight={styleOverrides.minHeight ?? ''}
+					minWidth={styleOverrides.minWidth ?? ''}
+					outline={styleOverrides.outline ?? ''}
+					padding={styleOverrides.padding ?? 0}
+					position="absolute"
+					whiteSpace="normal"
+					width={styleOverrides.width ?? 'auto'}
+					zIndex={styleOverrides.zIndex ?? 'menu'}
+					css={`
+						text-align: ${styleOverrides.textAlign ?? 'left'};
+						outline: none !important;
+						${styleOverrides.overflow ? `overflow: ${styleOverrides.overflow}` : ''};
+					`}
+					tabIndex="-1"
+					{...rest}
+				>
+					{children}
+					{!hideArrow && (
+						<Box
+							ref={arrowProps.ref}
+							style={arrowProps.style}
+							css={`
+								width: 25px;
+								height: 25px;
+								position: absolute;
+								overflow: hidden;
+								pointer-events: none;
+								text-align: center;
+								--bg: ${({ theme }) => theme.colors.popover.background};
+								--shadow: ${({ theme }) => theme.shadows[1]};
+
+								&::after {
+									content: '';
+									border: ${styleOverrides?.border ?? 'none'};
+									position: absolute;
+									width: ${arrowWidth};
+									height: ${arrowWidth};
+									background: ${theme?.backgroundColor ?? 'var(--bg)'};
+									transform: translateX(-50%) translateY(-50%) rotate(45deg);
+									box-shadow: ${styleOverrides?.hideShadow ? 'none' : 'var(--shadow)'};
+								}
+								${placement ? arrowStyles[getPlacement(placement)] : arrowStyles.top};
+							`}
+						/>
+					)}
+				</Box>
+			)}
+		</Popper>
+	);
 }

--- a/components/popover/popover-manager.jsx
+++ b/components/popover/popover-manager.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Manager } from 'react-popper';
-import { useFocusAwayHandler } from '../shared-hooks';
 import { PopoverContext } from './popper-helpers';
 
-export function PopoverManager({ children, onFocusAway, ...props }) {
-	const targetRef = useFocusAwayHandler(onFocusAway);
+export function PopoverManager({ children, onFocusAway }) {
 	return (
 		<Manager>
-			<PopoverContext.Provider value={{ targetRef }}>{children}</PopoverContext.Provider>
+			<PopoverContext.Provider value={{ onFocusAway }}>{children}</PopoverContext.Provider>
 		</Manager>
 	);
 }

--- a/components/popover/popover-manager.jsx
+++ b/components/popover/popover-manager.jsx
@@ -2,33 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Manager } from 'react-popper';
 import { useFocusAwayHandler } from '../shared-hooks';
-import { Box } from '../Box';
 import { PopoverContext } from './popper-helpers';
 
 export function PopoverManager({ children, onFocusAway, ...props }) {
-	const { targetRef, addInboundsElement, removeInboundsElement } = useFocusAwayHandler(onFocusAway);
+	const targetRef = useFocusAwayHandler(onFocusAway);
 	return (
 		<Manager>
-			<PopoverContext.Provider value={{ addInboundsElement, removeInboundsElement }}>
-				{onFocusAway ? (
-					<Box
-						css={`
-							&:focus {
-								outline: none;
-								box-shadow: none;
-							}
-						`}
-						ref={targetRef}
-						display="inline-block"
-						tabIndex="-1"
-						{...props}
-					>
-						{children}
-					</Box>
-				) : (
-					children
-				)}
-			</PopoverContext.Provider>
+			<PopoverContext.Provider value={{ targetRef }}>{children}</PopoverContext.Provider>
 		</Manager>
 	);
 }

--- a/components/popover/popper-helpers.jsx
+++ b/components/popover/popper-helpers.jsx
@@ -1,16 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
-import { useAddInboundsElement } from '../shared-hooks';
 import { Box } from '../Box';
 
 export const PopoverContext = React.createContext();
-
-export function usePopoverContext() {
-	const popoverContext = useContext(PopoverContext);
-
-	return popoverContext;
-}
 
 /** Popover reference container from react-popper */
 export const PopoverReference = ({ children, ...referenceProps }) => (
@@ -29,21 +22,6 @@ export const PopoverReference = ({ children, ...referenceProps }) => (
 
 PopoverReference.propTypes = {
 	children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-};
-
-export function FocusHandlerInboundsElement({ children }) {
-	const { addInboundsElement, removeInboundsElement } = usePopoverContext();
-	const targetRef = useAddInboundsElement(addInboundsElement, removeInboundsElement);
-
-	return (
-		<div ref={targetRef} tabIndex="-1">
-			{children}
-		</div>
-	);
-}
-
-FocusHandlerInboundsElement.propTypes = {
-	children: PropTypes.node.isRequired,
 };
 
 export const PlainPopoverReference = Reference;

--- a/components/shared-hooks/index.js
+++ b/components/shared-hooks/index.js
@@ -1,5 +1,5 @@
 export { useId } from './use-id';
 export { useBasicMap } from './use-basic-map';
-export { useFocusAwayHandler, useAddInboundsElement } from './use-focus-away-handler';
+export { useFocusAwayHandler } from './use-focus-away-handler';
 export { useDebouncedCallback } from './use-debounced-callback';
 export { useCopyRefs } from './use-copy-refs';

--- a/components/shared-hooks/use-focus-away-handler.js
+++ b/components/shared-hooks/use-focus-away-handler.js
@@ -1,6 +1,6 @@
-/* eslint eqeqeq: ["error", "always", {"null": "never"}] */
 import { useRef, useEffect } from 'react';
 
+const isNullOrUndefined = v => v === null || v === undefined;
 export function useFocusAwayHandler(onFocusAway) {
 	const targetRef = useRef();
 	const focusAwayRef = useRef();
@@ -8,7 +8,7 @@ export function useFocusAwayHandler(onFocusAway) {
 
 	useEffect(() => {
 		const handleFocusIn = event => {
-			if (targetRef.current == null || focusAwayRef.current == null) {
+			if (isNullOrUndefined(targetRef.current) || isNullOrUndefined(focusAwayRef.current)) {
 				return;
 			}
 
@@ -18,7 +18,7 @@ export function useFocusAwayHandler(onFocusAway) {
 			}
 		};
 		const handleFocusOut = event => {
-			if (targetRef.current == null || focusAwayRef.current == null) {
+			if (isNullOrUndefined(targetRef.current) || isNullOrUndefined(focusAwayRef.current)) {
 				return;
 			}
 

--- a/components/shared-hooks/use-focus-away-handler.js
+++ b/components/shared-hooks/use-focus-away-handler.js
@@ -7,6 +7,9 @@ export function useFocusAwayHandler(onFocusAway) {
 	focusAwayRef.current = onFocusAway;
 
 	useEffect(() => {
+		const previousFocus = document.activeElement;
+		targetRef.current.focus({ preventScroll: true });
+
 		const handleFocusIn = event => {
 			if (isNullOrUndefined(targetRef.current) || isNullOrUndefined(focusAwayRef.current)) {
 				return;
@@ -14,6 +17,7 @@ export function useFocusAwayHandler(onFocusAway) {
 
 			const target = event.target ?? document.activeElement;
 			if (target !== targetRef.current && !targetRef.current.contains(target)) {
+				previousFocus?.focus();
 				focusAwayRef.current();
 			}
 		};
@@ -24,6 +28,7 @@ export function useFocusAwayHandler(onFocusAway) {
 
 			const target = event.relatedTarget ?? document.activeElement;
 			if (target !== targetRef.current && !targetRef.current.contains(target)) {
+				previousFocus?.focus({ preventScroll: true });
 				focusAwayRef.current();
 			}
 		};

--- a/components/utils/focus-away-handler.jsx
+++ b/components/utils/focus-away-handler.jsx
@@ -1,15 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useFocusAwayHandler } from '../shared-hooks';
 
 export function FocusAwayHandler({ children, onFocusAway }) {
 	const targetRef = useFocusAwayHandler(onFocusAway);
-
-	useEffect(() => {
-		if (onFocusAway && targetRef.current) {
-			targetRef.current.focus();
-		}
-	}, [onFocusAway, targetRef]);
 
 	if (!onFocusAway) {
 		return children;

--- a/components/utils/merge-refs.js
+++ b/components/utils/merge-refs.js
@@ -1,0 +1,11 @@
+export function mergeRefs(...refs) {
+	return v => {
+		for (const ref of refs) {
+			if (ref instanceof Function) {
+				ref(v);
+			} else {
+				ref.current = v;
+			}
+		}
+	};
+}

--- a/index-v6.js
+++ b/index-v6.js
@@ -1,2 +1,3 @@
 export { Modal } from './components/modal';
 export { Button, SegmentedButtonGroup } from './components/button';
+export { usePopover, Popover } from './components/popover-v6';

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		}
 	},
 	"dependencies": {
+		"@popperjs/core": "^2.4.0",
 		"@styled-system/prop-types": "^5.1.1",
 		"@styled-system/theme-get": "^5.1.1",
 		"clipboard": "^2.0.1",
@@ -66,7 +67,7 @@
 		"memoize-one": "^5.0.0",
 		"prop-types": "^15.6.1",
 		"react-bootstrap-typeahead": "^3.4.5",
-		"react-popper": "^1.3.3",
+		"react-popper": "^2.2.3",
 		"react-scrollbar": "^0.5.4",
 		"react-select": "^2",
 		"react-transition-group": "^4.4.1",
@@ -107,7 +108,7 @@
 		"micro-graphql-react": "^0.3.0-beta2",
 		"mini-css-extract-plugin": "^0.4.1",
 		"mocha": "^5.1.1",
-		"node-sass": "^4.12.0",
+		"node-sass": "^4.14.1",
 		"postcss-inline-svg": "^3.1.1",
 		"postcss-loader": "^2.1.6",
 		"prettier": "^1.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,6 +1477,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@popperjs/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
+  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -9087,10 +9092,10 @@ node-releases@^1.1.49:
   dependencies:
     semver "^6.3.0"
 
-node-sass@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
-  integrity sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==
+node-sass@^4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
+  integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -9099,14 +9104,14 @@ node-sass@^4.12.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.13.2"
     node-gyp "^3.8.0"
     npmlog "^4.0.0"
     request "^2.88.0"
-    sass-graph "^2.2.4"
+    sass-graph "2.2.5"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
@@ -10691,6 +10696,11 @@ react-error-overlay@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
   integrity sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw==
 
+react-fast-compare@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.1.1.tgz#0becf31e3812fa70dc231e259f40d892d4767900"
+  integrity sha512-SCsAORWK59BvauR2L1BTdjQbJcSGJJz03U0awektk2hshLKrITDDFTlgGCqIZpTDlPC/NFlZee6xTMzXPVLiHw==
+
 react-input-autosize@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
@@ -10737,7 +10747,7 @@ react-popper@^0.10.4:
     popper.js "^1.14.1"
     prop-types "^15.6.1"
 
-react-popper@^1.0.0, react-popper@^1.3.3:
+react-popper@^1.0.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
   integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
@@ -10747,6 +10757,14 @@ react-popper@^1.0.0, react-popper@^1.3.3:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-router-scroll@^0.4.2:
@@ -11456,15 +11474,15 @@ sander@^0.6.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-sass-graph@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
-  integrity sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=
+sass-graph@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
+  integrity sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==
   dependencies:
     glob "^7.0.0"
     lodash "^4.0.0"
     scss-tokenizer "^0.2.3"
-    yargs "^7.0.0"
+    yargs "^13.3.2"
 
 sass-loader@^7.0.3:
   version "7.0.3"
@@ -13523,17 +13541,18 @@ yargs-parser@^13.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
   integrity sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=
-  dependencies:
-    camelcase "^3.0.0"
-
-yargs-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
-  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:
     camelcase "^3.0.0"
 
@@ -13605,24 +13624,21 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
-  integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
+yargs@^13.3.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
   dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
     require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
+    require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^5.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
Updates react-popper to v2, and introduces a new version of `Popover` which uses the new hook-based api.

The old popover is left mostly as-is, and maps a handful of older props to the newer equivalents.
The exception is the `modifiers` prop, as the modifiers api has changed. However, a github search shows only one consumer even uses a modifier, so I am willing to contribute a fix to that consumer.

Questions you may have:
Q: Where's the v6 PopoverBase equivalent?
A: PopoverBase appears to exist solely to provide an unstyled version of the popover. Since we expose `usePopover`, a consumer can simply use that with a `Box` to get an unstyled version.

Q: What about the Tooltip component?
A: I think the new popover covers the same usecases as tooltip. If not, however, it should be pretty straightforward to add one that uses the new popover.

Q: Why does the api use `useState` for the popper and arrow refs, instead of `useRef`?
A: the short answer is, this is what's shown in the [react-popper docs](https://popper.js.org/react-popper/v2/#example).
The long answer is, the `usePopper` api accepts dom elements, and not ref objects. I'm not *entirely* sure why this is, but I *think* it has to do with changes to ref objects not typically causing `useEffect` effects to rerun. and usePopper has to dispose and/or construct the internal `popper` instance any time these references change (to and from `null`, or to a different dom element).
As best I can tell, this wouldn't work with `ref`s, because deps are checked *before* render, and refs are updated *after* render. So, as unfortunate as it is, initializing the popper takes two rerenders.

element states start out null. A setstate is fired when we render an element (which may not be on the first render, it could be down the road), which triggers a rerender. useEffect sees that the the elements changed, and so will fire the effect after render. The effect will create a popper instance, and the popper instance will calculate styles. Finally, the popper instance will trigger one last rerender to pass the calculated styles to the component.