### PR TITLE
Add placeholder option for FilterInput

### DIFF
--- a/catalog/input/input.md
+++ b/catalog/input/input.md
@@ -66,7 +66,7 @@ Use in UI that needs to inline-filter a list.
 showSource: true
 state: { value: 'Washington' }
 ---
-<FilterInput variant="medium" value={state.value} onChange={event => setState({ value: event.target.value })} onClear={() => setState({ value: '' })} />
+<FilterInput variant="medium" placeholder="Find" value={state.value} onChange={event => setState({ value: event.target.value })} onClear={() => setState({ value: '' })} />
 ```
 
 ## NumberInput

--- a/components/input/FilterInput.jsx
+++ b/components/input/FilterInput.jsx
@@ -10,7 +10,7 @@ import { X as Close } from '../icons/18px';
 import { useCopyRefs } from '../shared-hooks/use-copy-refs';
 
 const FilterInput = React.forwardRef(function FilterInput(
-	{ value, onChange, onClear, variant, border, borderColor, borderWidth, ...props },
+	{ value, onChange, onClear, variant, border, borderColor, borderWidth, placeholder, ...props },
 	ref,
 ) {
 	if (!onClear) {
@@ -35,6 +35,7 @@ const FilterInput = React.forwardRef(function FilterInput(
 				<Input
 					ref={flattenedRef}
 					variant={variant}
+					placeholder={placeholder}
 					value={value}
 					border={border}
 					borderColor={borderColor}


### PR DESCRIPTION
Would like to use this component (i.e. `FilterInput`) for Sermon Manager (new in L9)...will take some minor styling hacks to make Logos-consistent, but nothing major or terribly awkward.  Would love to be able to include a `placeholder`, hence this PR.  cc: @bryanrsmith 