### PR TITLE
Only use focusAway logic if hanlder is passed

### DIFF
--- a/components/shared-hooks/use-focus-away-handler.js
+++ b/components/shared-hooks/use-focus-away-handler.js
@@ -7,11 +7,15 @@ export function useFocusAwayHandler(reference, onFocusAway) {
 	focusAwayRef.current = onFocusAway;
 
 	useEffect(() => {
+		if (!isNullOrUndefined(focusAwayRef.current)) {
+			return;
+		}
+
 		const previousFocus = document.activeElement;
 		targetRef.current.focus({ preventScroll: true });
 
 		const handleFocusIn = event => {
-			if (isNullOrUndefined(targetRef.current) || isNullOrUndefined(focusAwayRef.current)) {
+			if (isNullOrUndefined(targetRef.current)) {
 				return;
 			}
 
@@ -27,7 +31,7 @@ export function useFocusAwayHandler(reference, onFocusAway) {
 			}
 		};
 		const handleFocusOut = event => {
-			if (isNullOrUndefined(targetRef.current) || isNullOrUndefined(focusAwayRef.current)) {
+			if (isNullOrUndefined(targetRef.current)) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes a regression in Tooltips where some the focusAway logic would run even if no `focusAway` handler was passed in. This would cause tooltips which open when an input is focused to steal focus from the input (and subsequently closes the popup).

This change makes it such that the auto-focus of the popover only happens if the consumer passes a focusAway handler, to support use cases like the above where opening and closing the popover is entirely controlled by the consumer.