### PR TITLE
Fix disabled checkbox styling.

### DIFF
--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -10,13 +10,11 @@ export const CheckboxDiv = styled.div`
 	height: 16px;
 	background: ${({ theme }) => theme.colors.checkbox.background};
 
-	${props =>
-		props.disabled
+	${({ disabled, theme, themeOverrides }) =>
+		disabled
 			? `
-		border: solid 1px ${({ theme, themeOverrides }) =>
-			themeOverrides?.disabledBorder ?? theme.colors.checkbox.disabledBorder};
-		background-color: ${({ theme, themeOverrides }) =>
-			themeOverrides?.disabledBackground ?? theme.colors.checkbox.disabledBackground};
+		border: solid 1px ${themeOverrides?.disabledBorder ?? theme.colors.checkbox.disabledBorder};
+		background-color: ${themeOverrides?.disabledBackground ?? theme.colors.checkbox.disabledBackground};
 	`
 			: ''}
 `;


### PR DESCRIPTION
I noticed that the disable checkbox started looking like the normal checkbox recently. Eventually was able to track it down to this. I assume the string template inside the string template doesn't pass through the props again?