### PR TITLE
Do not make children required in `DropdownToggle`.

### DIFF
--- a/components/dropdown/dropdown-toggle.jsx
+++ b/components/dropdown/dropdown-toggle.jsx
@@ -40,5 +40,5 @@ export function DropdownToggle(props) {
 
 DropdownToggle.propTypes = {
 	/** The content of the toggle button, usually a span */
-	children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+	children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };


### PR DESCRIPTION
I believe a childless element like the following is a completely valid use case for `DropdownToggle`.
```jsx
<DropdownToggle
	variant="minorTransparent"
	condensed
	size="small"
	icon={<KebabVerticalIcon18 />}
/>
```

This already appears to be supported since the component does nothing interesting with `children`:
https://github.com/Faithlife/styled-ui/blob/8ba82b1ee45ab19684beccaa197b5700e97f412f/components/dropdown/dropdown-toggle.jsx#L36