### PR TITLE
Remove unused theme prop from ParameterSentence.

### DIFF
--- a/catalog/parameter-sentence/variations.md
+++ b/catalog/parameter-sentence/variations.md
@@ -80,7 +80,6 @@ state: {
 		onItemSelect={item => setState({ schedule: item })}
 		options={scheduleOptions}
 		accessibilityLabel={'Pay schedule of income'}
-		theme={{ underlineColor: 'plum' }}
 		styleOverrides={{ fontSize: '18px' }}
 	/>
 	<ParameterInputBox
@@ -90,7 +89,6 @@ state: {
 		formatValue={val => `${val}%`}
 		width="35px"
 		accessibilityLabel={'Percent of income to tithe'}
-		theme={{ underlineColor: 'plum' }}
 		styleOverrides={{ fontSize: '18px' }}
 	/>
 </ParameterSentenceDemo>

--- a/components/parameter-sentence/parameter-input.jsx
+++ b/components/parameter-sentence/parameter-input.jsx
@@ -11,7 +11,6 @@ export const ParameterInputBox = React.forwardRef((props, ref) => {
 		width,
 		accessibilityLabel,
 		styleOverrides,
-		theme,
 		onFocus,
 		onBlur,
 		...inputProps
@@ -42,7 +41,6 @@ export const ParameterInputBox = React.forwardRef((props, ref) => {
 		<Styled.InputContainer
 			width={width}
 			isFocused={isFocused}
-			theme={theme}
 			styleOverrides={{ width, ...styleOverrides }}
 		>
 			<Styled.Input
@@ -52,7 +50,6 @@ export const ParameterInputBox = React.forwardRef((props, ref) => {
 				onFocus={handleFocus}
 				onBlur={handleBlur}
 				value={!isFocused ? displayValue : value}
-				theme={theme}
 				aria-label={accessibilityLabel}
 				styleOverrides={{ width, ...styleOverrides }}
 				{...inputProps}
@@ -68,17 +65,11 @@ ParameterInputBox.propTypes = {
 	formatValue: PropTypes.func,
 	width: PropTypes.string,
 	accessibilityLabel: PropTypes.string.isRequired,
-	theme: PropTypes.shape({
-		hoverColor: PropTypes.string,
-		activeColor: PropTypes.string,
-		underlineColor: PropTypes.string,
-	}),
 	styleOverrides: PropTypes.shape({
 		fontSize: PropTypes.string,
 	}),
 };
 
 ParameterInputBox.defaultProps = {
-	theme: {},
 	styleOverrides: {},
 };

--- a/components/parameter-sentence/parameter-select.jsx
+++ b/components/parameter-sentence/parameter-select.jsx
@@ -13,7 +13,6 @@ export function ParameterSelect({
 	accessibilityLabel,
 	useNativeSelect,
 	styleOverrides,
-	theme,
 }) {
 	const [isOpen, setIsOpen] = useState(false);
 	const id = useId();
@@ -51,7 +50,7 @@ export function ParameterSelect({
 								type="button"
 								{...ariaProps}
 							>
-								<Styled.ButtonContent isOpen={isOpen} theme={theme} styleOverrides={styleOverrides}>
+								<Styled.ButtonContent isOpen={isOpen} styleOverrides={styleOverrides}>
 									{options[selectedId]}
 								</Styled.ButtonContent>
 							</Styled.Button>
@@ -70,7 +69,6 @@ export function ParameterSelect({
 				<Styled.Select
 					value={selectedId}
 					onChange={handleNativeSelect}
-					theme={theme}
 					styleOverrides={styleOverrides}
 					aria-labelledby={labelId}
 				>
@@ -95,11 +93,6 @@ ParameterSelect.propTypes = {
 	accessibilityLabel: PropTypes.string,
 	/** Use the native select controls (mobile only) */
 	useNativeSelect: PropTypes.bool,
-	theme: PropTypes.shape({
-		hoverColor: PropTypes.string,
-		activeColor: PropTypes.string,
-		underlineColor: PropTypes.string,
-	}),
 	styleOverrides: PropTypes.shape({
 		fontSize: PropTypes.string,
 	}),
@@ -108,5 +101,4 @@ ParameterSelect.propTypes = {
 ParameterSelect.defaultProps = {
 	width: '180px',
 	styleOverrides: {},
-	theme: {},
 };

--- a/components/parameter-sentence/styled.jsx
+++ b/components/parameter-sentence/styled.jsx
@@ -7,7 +7,7 @@ const selectStyling = css`
 	min-height: fit-content;
 	font-size: ${({ styleOverrides }) => styleOverrides.fontSize || '16px'};
 	width: ${({ styleOverrides }) => styleOverrides.width};
-	border-bottom: dashed ${thickness.two} ${({ theme }) => theme.underlineColor || colors.blueBase};
+	border-bottom: dashed ${thickness.two} ${colors.blueBase};
 	font-weight: bold;
 	color: ${colors.gray66};
 	${props => `color: ${props.isOpen ? colors.blueActive : colors.gray66}`};
@@ -18,12 +18,12 @@ const selectStyling = css`
 
 	&:hover {
 		&:not(:focus) {
-			color: ${({ theme }) => theme.hoverColor || colors.blueBase};
+			color: ${colors.blueBase};
 		}
 	}
 
 	&:active {
-		color: ${({ theme }) => theme.activeColor || colors.blueActive};
+		color: ${colors.blueActive};
 	}
 
 	&:focus {
@@ -103,7 +103,7 @@ export const InputContainer = styled.div`
 	${selectStyling};
 
 	border-bottom: ${({ isFocused }) => (isFocused ? 'solid' : 'dashed')} ${thickness.two}
-		${({ theme }) => theme.underlineColor || colors.blueBase};
+		${colors.blueBase};
 
 	height: ${({ styleOverrides }) => styleOverrides.fontSize || '16px'};
 


### PR DESCRIPTION
This `theme` prop was overriding Styled-UI's styled-system theme, breaking the ParameterSentence dropdown component.

https://faithlife.github.io/styled-ui/#/parameter-sentence/variations

Expected: clicking on parameter in the parameter sentence does not explode the page
Actual: explodes the page