### PR TITLE
add optional prop for number input to always show increment buttons

### DIFF
--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import { Box } from '../Box';
 import { Input } from './Input';
@@ -57,6 +58,7 @@ const NumberInput = React.memo(
 					paddingTop={buttonPadding}
 					icon={<ChevronUp />}
 					disabled={props.disabled}
+					alwaysShowButtons={props.alwaysShowButtons}
 				/>
 				<StepButton
 					onClick={handleStepDown}
@@ -64,6 +66,7 @@ const NumberInput = React.memo(
 					paddingBottom={buttonPadding}
 					icon={<ChevronDown />}
 					disabled={props.disabled}
+					alwaysShowButtons={props.alwaysShowButtons}
 				/>
 			</InputContainer>
 		);
@@ -72,10 +75,12 @@ const NumberInput = React.memo(
 
 NumberInput.defaultProps = {
 	theme,
+	alwaysShowButtons: false,
 };
 
 NumberInput.propTypes = {
 	...Input.PropTypes,
+	alwaysShowButtons: PropTypes.bool,
 };
 
 const InputContainer = ({ children, ...props }) => (
@@ -99,7 +104,11 @@ const StepButton = props => (
 		size="small"
 		css={`
 			height: 50%;
-			visibility: hidden;
+
+			${!props.alwaysShowButtons &&
+				css`
+					visibility: hidden;
+				`}
 
 			${!props.disabled &&
 				css`

--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -75,7 +75,6 @@ const NumberInput = React.memo(
 
 NumberInput.defaultProps = {
 	theme,
-	alwaysShowButtons: false,
 };
 
 NumberInput.propTypes = {


### PR DESCRIPTION
this is part of the work being done on [SITES-6418](https://faithlife.atlassian.net/browse/SITES-6418) where we would like to use the NumberInput for the quantity selector, but it has been requested that the buttons are always shown within the input, not just on hover/focus.