### PR TITLE
Remove unnecessary padding in Accordion.Header to match spec.

### DIFF
--- a/components/accordion/accordion-header.jsx
+++ b/components/accordion/accordion-header.jsx
@@ -157,6 +157,6 @@ const Button = styled(UtilityButton).attrs(({ isExpanded, panelId, headerId }) =
 const ButtonContent = styled(Box).attrs(() => ({ gridGap: 4 }))`
 	display: inline-grid;
 	grid-template-columns: min-content auto;
-	align-items: center;
+	align-items: baseline;
 	white-space: nowrap;
 `;

--- a/components/accordion/accordion-header.jsx
+++ b/components/accordion/accordion-header.jsx
@@ -80,7 +80,7 @@ export function AccordionHeader({
 					hideArrows={shouldHideArrows}
 				>
 					{!shouldHideArrows && (
-						<Box marginRight={variant === 'minimal' ? 3 : 4} lineHeight={0} alignSelf="center">
+						<Box lineHeight={0} alignSelf="center">
 							{isExpanded ? <ChevronDown /> : <ChevronRight />}
 						</Box>
 					)}
@@ -154,7 +154,7 @@ const Button = styled(UtilityButton).attrs(({ isExpanded, panelId, headerId }) =
 	line-height: 1;
 `;
 
-const ButtonContent = styled(Box).attrs(() => ({ gridGap: 6 }))`
+const ButtonContent = styled(Box).attrs(() => ({ gridGap: 4 }))`
 	display: inline-grid;
 	grid-template-columns: min-content auto;
 	align-items: center;


### PR DESCRIPTION
The marginRight on the arrow container is unnecessary because of the grid gap on the containing Button.
I confirmed with Amber that we want a consistent 12px gap between caret and title, and between title and subtitle, on both the minimal variant and the normal variant.