### PR TITLE
Center the date picker arrow buttons

### DIFF
--- a/components/date-picker/styled.jsx
+++ b/components/date-picker/styled.jsx
@@ -4,6 +4,7 @@ import { colors } from '../shared-styles';
 export const ChangeMonth = styled.button`
 	display: flex;
 	justify-content: space-around;
+	align-items: center;
 	border: none;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Aligned the date picker's previous and next month's buttons centered according to the [spec](https://app.zeplin.io/project/58a23c2d4597afb248c13a43/screen/5bedfd6811d4fc12b2f92d4a).

Link to Issue: https://github.com/Faithlife/styled-ui/issues/368