### PR TITLE
SUI-13 - Add Avatar Selects

### DIFF
--- a/catalog/input/pages.js
+++ b/catalog/input/pages.js
@@ -1,7 +1,7 @@
 import { pageLoader } from 'catalog';
 import styled from 'styled-components';
 import { InferredTypeahead, Typeahead } from '../../components/text-input';
-import { Select, CreatableSelect, AvatarSelect } from '../../components/text-input-v2';
+import { Select, CreatableSelect, avatarComponents } from '../../components/text-input-v2';
 import { DocgenTable } from '../docgen-table';
 import { Bootstrap, Button, Input, NumberInput, Modal, FilterInput } from '../../index';
 import {
@@ -47,7 +47,7 @@ export const textInputPages = {
 				DemoDiv: styled.div`
 					width: 256px;
 				`,
-				AvatarSelect,
+				avatarComponents,
 			},
 		},
 		{

--- a/catalog/input/pages.js
+++ b/catalog/input/pages.js
@@ -1,7 +1,7 @@
 import { pageLoader } from 'catalog';
 import styled from 'styled-components';
 import { InferredTypeahead, Typeahead } from '../../components/text-input';
-import { Select, CreatableSelect } from '../../components/text-input-v2';
+import { Select, CreatableSelect, AvatarSelect } from '../../components/text-input-v2';
 import { DocgenTable } from '../docgen-table';
 import { Bootstrap, Button, Input, NumberInput, Modal, FilterInput } from '../../index';
 import {
@@ -47,6 +47,7 @@ export const textInputPages = {
 				DemoDiv: styled.div`
 					width: 256px;
 				`,
+				AvatarSelect,
 			},
 		},
 		{

--- a/catalog/input/select.md
+++ b/catalog/input/select.md
@@ -153,7 +153,8 @@ state: { tags: [] }
 ```react
 showSource: true
 ---
-<AvatarSelect
+<Select
+	components={avatarComponents}
 	isMulti
 	options={[
 		{ value: "california", label: "California" },

--- a/catalog/input/select.md
+++ b/catalog/input/select.md
@@ -148,6 +148,21 @@ state: { tags: [] }
 <AsyncSelectDemo />
 ```
 
+### Avatar Select
+
+```react
+showSource: true
+---
+<AvatarSelect
+	isMulti
+	options={[
+		{ value: "california", label: "California" },
+		{ value: "washington", label: "Washington", avatar: "https://files.logoscdn.com/v1/files/42382171/content.svg?signature=6V_cO8zkG4kob-qZTjNlJkCuNTA" },
+		{ value: "texas", label: "Texas", avatar: "https://files.logoscdn.com/v1/files/42382171/content.svg?signature=6V_cO8zkG4kob-qZTjNlJkCuNTA", "secondaryLabel": "The Lonestar State" }
+	]}
+/>
+```
+
 ### Custom Options select
 
 ```react

--- a/components/text-input-v2/index.js
+++ b/components/text-input-v2/index.js
@@ -3,7 +3,7 @@ export {
 	CreatableSelect,
 	AsyncCreatableSelect,
 	Select,
-	AvatarSelect,
+	avatarComponents,
 	reactSelectComponents,
 } from './select';
 export { InferredText } from './inferred-text';

--- a/components/text-input-v2/index.js
+++ b/components/text-input-v2/index.js
@@ -3,6 +3,7 @@ export {
 	CreatableSelect,
 	AsyncCreatableSelect,
 	Select,
+	AvatarSelect,
 	reactSelectComponents,
 } from './select';
 export { InferredText } from './inferred-text';

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -330,22 +330,6 @@ export const AsyncSelect = React.forwardRef(({ components = {}, ...props }, ref)
 	);
 });
 
-export const AvatarSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
-	return <Select ref={ref} {...props} components={{ ...avatarComponents }} />;
-});
-
-export const AvatarCreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
-	return <CreatableSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
-});
-
-export const AvatarAsyncCreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
-	return <AsyncCreatableSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
-});
-
-export const AvatarAsyncSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
-	return <AsyncSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
-});
-
 function useBody() {
 	const [body, setBody] = useState(null);
 	useEffect(() => {

--- a/components/text-input-v2/select.jsx
+++ b/components/text-input-v2/select.jsx
@@ -6,6 +6,7 @@ import ReactSelect, {
 import { colors } from '../shared-styles';
 import { ChevronDown } from '../icons/12px';
 import { DebouncedSelectAsync, DebouncedSelectAsyncCreatable } from './debounced-async';
+import * as Styled from './styled';
 import { ThemedBox } from '../ThemedBox';
 import { useTheme } from '../../theme';
 
@@ -155,6 +156,53 @@ const defaultComponents = {
 	),
 };
 
+const AvatarOption = ({ data: { avatar, label, secondaryLabel }, ...props }) => {
+	const theme = useTheme();
+
+	return (
+		<Styled.AvatarOption {...props}>
+			{avatar ? (
+				<>
+					<Styled.AvatarOptionImage src={avatar} alt={label} />
+					<Styled.AvatarOptionText theme={theme}>
+						<Styled.AvatarOptionName theme={theme}>{label}</Styled.AvatarOptionName>
+						{secondaryLabel && (
+							<Styled.AvatarOptionSecondaryLabel theme={theme}>
+								{secondaryLabel}
+							</Styled.AvatarOptionSecondaryLabel>
+						)}
+					</Styled.AvatarOptionText>
+				</>
+			) : (
+				label
+			)}
+		</Styled.AvatarOption>
+	);
+};
+
+const AvatarMultiValue = ({ data: { avatar, label }, ...props }) => {
+	const theme = useTheme();
+
+	return (
+		<Styled.AvatarMultiValue {...props}>
+			{avatar ? (
+				<>
+					<Styled.AvatarMultiValueImage src={avatar} alt={label} />
+					<Styled.AvatarMultiValueName theme={theme}>{label}</Styled.AvatarMultiValueName>
+				</>
+			) : (
+				label
+			)}
+		</Styled.AvatarMultiValue>
+	);
+};
+
+export const avatarComponents = {
+	...defaultComponents,
+	Option: AvatarOption,
+	MultiValue: AvatarMultiValue,
+};
+
 function noOptionsMessage({ inputValue }) {
 	return inputValue ? 'No options' : null;
 }
@@ -280,6 +328,22 @@ export const AsyncSelect = React.forwardRef(({ components = {}, ...props }, ref)
 			onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 		/>
 	);
+});
+
+export const AvatarSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
+	return <Select ref={ref} {...props} components={{ ...avatarComponents }} />;
+});
+
+export const AvatarCreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
+	return <CreatableSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
+});
+
+export const AvatarAsyncCreatableSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
+	return <AsyncCreatableSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
+});
+
+export const AvatarAsyncSelect = React.forwardRef(({ components = {}, ...props }, ref) => {
+	return <AsyncSelect ref={ref} {...props} components={{ ...avatarComponents }} />;
 });
 
 function useBody() {

--- a/components/text-input-v2/styled.jsx
+++ b/components/text-input-v2/styled.jsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { components as reactSelectComponents } from 'react-select';
+
+export const AvatarOption = styled(reactSelectComponents.Option)`
+	&& {
+		align-items: center;
+		display: flex;
+	}
+`;
+
+export const AvatarOptionImage = styled.img`
+	border-radius: 10%;
+	height: 40px;
+	width: 40px;
+`;
+
+export const AvatarOptionText = styled.div`
+	padding: ${props => props.theme.space[2]};
+`;
+
+export const AvatarOptionName = styled.div`
+	color: ${props => props.theme.colors.gray66};
+	font-size: ${props => props.theme.fontSizes[3]};
+	font-weight: ${props => props.theme.fontWeights.bold};
+`;
+
+export const AvatarOptionSecondaryLabel = styled.div`
+	color: ${props => props.theme.colors.gray52};
+	font-size: ${props => props.theme.fontSizes[2]};
+`;
+
+export const AvatarMultiValue = styled(reactSelectComponents.MultiValue)`
+	align-items: center;
+	display: flex;
+	min-height: 26px;
+`;
+
+export const AvatarMultiValueImage = styled.img`
+	border-radius: 10%;
+	height: 18px;
+	width: 18px;
+`;
+
+export const AvatarMultiValueName = styled.span`
+	padding-left: ${props => props.theme.fontSizes[2]};
+`;


### PR DESCRIPTION
# [SUI-13](https://faithlife.atlassian.net/browse/SUI-13)

I am working on a People lookup component for Church Management.  This component uses an extremely common UX pattern of showing avatars for both the drop down options and the selected options.

### Demo
Check this out here: https://deploy-preview-381--faithlife-styled-ui.netlify.app/#/text-input/select?a=avatar-select

### Screenshot
<img width="1057" alt="Screen Shot 2020-11-09 at 1 15 08 PM" src="https://user-images.githubusercontent.com/2788269/98586107-db4e3180-228d-11eb-8335-c6178e6cd473.png">
