### PR TITLE
Fix overriding of styles on disabled buttons

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -7,18 +7,6 @@ import { common, typography } from '../../theme/system';
 import { buttonSizes, buttons } from '../../theme/buttons';
 import { theme } from '../../theme';
 
-const sizeVariant = variant({
-	prop: 'size',
-	scale: 'buttonSizes',
-	variants: buttonSizes,
-});
-
-const buttonVariant = variant({
-	prop: 'variant',
-	scale: 'buttons',
-	variants: buttons,
-});
-
 const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'active' : null }))`
 	box-sizing: border-box;
 	font-family: inherit;
@@ -55,10 +43,21 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 		margin-right: ${props => (props.hasChildren ? props.theme.space[2] : '')};
 	}
 
-	${sizeVariant}
-	${buttonVariant}
-	${textStyle};
+	${variant({
+		prop: 'size',
+		scale: 'buttonSizes',
+		variants: buttonSizes,
+	})};
 
+	${({ disabled }) => css`
+		${variant({
+			prop: 'variant',
+			scale: 'buttons',
+			variants: buttons(disabled),
+		})};
+	`}
+
+	${textStyle};
 	${common};
 	${typography};
 	${layout};

--- a/theme/buttons.js
+++ b/theme/buttons.js
@@ -21,152 +21,178 @@ export const buttonSizes = {
 	},
 };
 
-export const buttons = {
-	primary: {
-		color: 'button.primaryForeground',
-		backgroundColor: 'button.primaryBackground',
-		border: 1,
-		borderColor: 'button.primaryBackground',
-		'&:hover': {
-			backgroundColor: 'button.primaryHover',
-			borderColor: 'button.primaryHover',
+export const buttons = disabled => {
+	return {
+		primary: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.primaryForegroundDisabled',
+						backgroundColor: 'button.primaryDisabled',
+						borderColor: 'button.primaryDisabled',
+				  }
+				: {
+						color: 'button.primaryForeground',
+						backgroundColor: 'button.primaryBackground',
+						borderColor: 'button.primaryBackground',
+						'&:hover': {
+							backgroundColor: 'button.primaryHover',
+							borderColor: 'button.primaryHover',
+						},
+						'&:active': {
+							backgroundColor: 'button.primaryActive',
+							borderColor: 'button.primaryActive',
+						},
+				  }),
 		},
-		'&:active': {
-			backgroundColor: 'button.primaryActive',
-			borderColor: 'button.primaryActive',
+		secondary: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.primaryDisabled',
+						borderColor: 'button.primaryDisabled',
+						backgroundColor: 'button.primaryForeground',
+				  }
+				: {
+						color: 'button.primaryBackground',
+						backgroundColor: 'button.primaryForeground',
+						borderColor: 'button.primaryBackground',
+						'&:hover': {
+							color: 'button.primaryForeground',
+							backgroundColor: 'button.primaryBackground',
+						},
+						'&:active': {
+							color: 'button.primaryForeground',
+							backgroundColor: 'button.primaryActive',
+							borderColor: 'button.primaryActive',
+						},
+				  }),
 		},
-		'&:disabled': {
-			color: 'button.primaryForegroundDisabled',
-			backgroundColor: 'button.primaryDisabled',
-			borderColor: 'button.primaryDisabled',
+		minor: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.minorForegroundDisabled',
+						backgroundColor: 'button.minorDisabled',
+						borderColor: 'button.minorDisabled',
+				  }
+				: {
+						color: 'button.minorForeground',
+						backgroundColor: 'button.minorBackground',
+						borderColor: 'button.minorBackground',
+						'&:hover': {
+							backgroundColor: 'button.minorHover',
+							borderColor: 'button.minorHover',
+						},
+						'&:active': {
+							backgroundColor: 'button.minorActive',
+							borderColor: 'button.minorActive',
+						},
+				  }),
 		},
-	},
-	secondary: {
-		border: 1,
-		color: 'button.primaryBackground',
-		backgroundColor: 'button.primaryForeground',
-		borderColor: 'button.primaryBackground',
-		'&:hover': {
-			color: 'button.primaryForeground',
-			backgroundColor: 'button.primaryBackground',
+		transparent: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.minorForegroundDisabled',
+						backgroundColor: 'transparent',
+				  }
+				: {
+						color: 'button.minorForeground',
+						backgroundColor: 'transparent',
+						borderColor: 'transparent',
+						'&:hover': {
+							backgroundColor: 'button.transparentHover',
+							borderColor: 'button.transparentHover',
+						},
+						'&:active,&.active': {
+							backgroundColor: 'button.primaryDisabled',
+							borderColor: 'button.primaryDisabled',
+							color: 'button.primaryActive',
+						},
+				  }),
 		},
-		'&:active': {
-			color: 'button.primaryForeground',
-			backgroundColor: 'button.primaryActive',
-			borderColor: 'button.primaryActive',
+		minorTransparent: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.primaryDisabled',
+						backgroundColor: 'transparent',
+				  }
+				: {
+						color: 'button.minorForeground',
+						backgroundColor: 'transparent',
+						borderColor: 'transparent',
+						'&:hover': {
+							color: 'button.primaryBackground',
+						},
+						'&:active,&.active': {
+							color: 'button.primaryActive',
+						},
+				  }),
 		},
-		'&:disabled': {
-			color: 'button.primaryDisabled',
-			borderColor: 'button.primaryDisabled',
-			backgroundColor: 'button.primaryForeground',
+		link: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.primaryDisabled',
+				  }
+				: {
+						color: 'button.primaryBackground',
+						backgroundColor: 'transparent',
+						borderColor: 'transparent',
+						'&:hover': {
+							color: 'button.primaryHover',
+						},
+						'&:active': {
+							color: 'button.primaryActive',
+						},
+				  }),
 		},
-	},
-	minor: {
-		border: 1,
-		color: 'button.minorForeground',
-		backgroundColor: 'button.minorBackground',
-		borderColor: 'button.minorBackground',
-		'&:hover': {
-			backgroundColor: 'button.minorHover',
-			borderColor: 'button.minorHover',
+		danger: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.dangerDisabled',
+						backgroundColor: 'button.dangerForeground',
+						borderColor: 'button.dangerDisabled',
+				  }
+				: {
+						color: 'button.dangerBackground',
+						backgroundColor: 'button.dangerForeground',
+						borderColor: 'button.dangerBackground',
+						'&:hover': {
+							color: 'button.dangerForeground',
+							backgroundColor: 'button.dangerBackground',
+							borderColor: 'button.dangerBackground',
+						},
+						'&:active': {
+							backgroundColor: 'button.dangerActive',
+							borderColor: 'button.dangerActive',
+						},
+				  }),
 		},
-		'&:active': {
-			backgroundColor: 'button.minorActive',
-			borderColor: 'button.minorActive',
+		dangerSpecial: {
+			border: 1,
+			...(disabled
+				? {
+						color: 'button.dangerForegroundDisabled',
+						backgroundColor: 'button.dangerDisabled',
+						borderColor: 'button.dangerDisabled',
+				  }
+				: {
+						color: 'button.dangerForeground',
+						backgroundColor: 'button.dangerBackground',
+						borderColor: 'button.dangerBackground',
+						'&:hover': {
+							backgroundColor: 'button.dangerHover',
+							borderColor: 'button.dangerHover',
+						},
+						'&:active': {
+							backgroundColor: 'button.dangerActive',
+							borderColor: 'button.dangerActive',
+						},
+				  }),
 		},
-		'&:disabled': {
-			color: 'button.minorForegroundDisabled',
-			backgroundColor: 'button.minorDisabled',
-			borderColor: 'button.minorDisabled',
-		},
-	},
-	transparent: {
-		border: 1,
-		color: 'button.minorForeground',
-		backgroundColor: 'transparent',
-		borderColor: 'transparent',
-		'&:hover': {
-			backgroundColor: 'button.transparentHover',
-			borderColor: 'button.transparentHover',
-		},
-		'&:active,&.active': {
-			backgroundColor: 'button.primaryDisabled',
-			borderColor: 'button.primaryDisabled',
-			color: 'button.primaryActive',
-		},
-		'&:disabled': {
-			color: 'button.minorForegroundDisabled',
-			backgroundColor: 'transparent',
-		},
-	},
-	minorTransparent: {
-		border: 1,
-		color: 'button.minorForeground',
-		backgroundColor: 'transparent',
-		borderColor: 'transparent',
-		'&:hover': {
-			color: 'button.primaryBackground',
-		},
-		'&:active,&.active': {
-			color: 'button.primaryActive',
-		},
-		'&:disabled': {
-			color: 'button.primaryDisabled',
-			backgroundColor: 'transparent',
-		},
-	},
-	link: {
-		border: 1,
-		color: 'button.primaryBackground',
-		backgroundColor: 'transparent',
-		borderColor: 'transparent',
-		'&:hover': {
-			color: 'button.primaryHover',
-		},
-		'&:active': {
-			color: 'button.primaryActive',
-		},
-		'&:disabled': {
-			color: 'button.primaryDisabled',
-		},
-	},
-	danger: {
-		border: 1,
-		color: 'button.dangerBackground',
-		backgroundColor: 'button.dangerForeground',
-		borderColor: 'button.dangerBackground',
-		'&:hover': {
-			color: 'button.dangerForeground',
-			backgroundColor: 'button.dangerBackground',
-			borderColor: 'button.dangerBackground',
-		},
-		'&:active': {
-			backgroundColor: 'button.dangerActive',
-			borderColor: 'button.dangerActive',
-		},
-		'&:disabled': {
-			color: 'button.dangerDisabled',
-			backgroundColor: 'button.dangerForeground',
-			borderColor: 'button.dangerDisabled',
-		},
-	},
-	dangerSpecial: {
-		border: 1,
-		color: 'button.dangerForeground',
-		backgroundColor: 'button.dangerBackground',
-		borderColor: 'button.dangerBackground',
-		'&:hover': {
-			backgroundColor: 'button.dangerHover',
-			borderColor: 'button.dangerHover',
-		},
-		'&:active': {
-			backgroundColor: 'button.dangerActive',
-			borderColor: 'button.dangerActive',
-		},
-		'&:disabled': {
-			color: 'button.dangerForegroundDisabled',
-			backgroundColor: 'button.dangerDisabled',
-			borderColor: 'button.dangerDisabled',
-		},
-	},
+	};
 };


### PR DESCRIPTION
Hello! First, a quick question: am I allowed to contribute to this repo without being a Faithlife employee? I ask because [`package.json`](https://github.com/Faithlife/styled-ui/blob/b554c0dd2447d8981fb3d36c0f9f67ecc1ee0d86/package.json#L6) says `"license": "UNLICENSED"`, and the reason I'm interested in this repo is because I'm applying for a job and wanted to start familiarizing myself with the codebase. I promise I won't use Faithlife Styled UI myself; I'm just browsing and committing for educational purposes. 😊

Anyway, if my contributing is okay, I believe I've fixed #382! Comparing the v6 `Button` to `LegacyButton` I saw that `LegacyButton` defined default styles for disabled buttons based on the `disabled` prop, not the `:disabled` CSS pseudo-class. What's happening in the v6 `Button` is that using the Styled System props only changes the properties of the main `button` selector, but if the button is disabled, the increased specificity of `button:disabled` causes it to still win out.

So this PR swaps the `:disabled` pseudo-class out for a `disabled` prop in the v6 `Button` styles.

<img width="423" alt="Screen Shot 2020-11-16 at 10 43 21 PM" src="https://user-images.githubusercontent.com/5317080/99483233-cc215080-292b-11eb-8c30-a89442b62ccd.png">