### PR TITLE
Fix AnchorButton compatibility with wrapped anchors

### DIFF
--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -75,51 +75,51 @@ export const Button = styled.button`
 
 	${({ as: baseTag }) => baseTag && baseTag === 'a' && Anchor};
 
-		${({ disabled }) =>
-			variant({
-				variants: {
-					primary: {
-						border: '1px solid',
-						color: 'white',
-						'@media (hover: hover)': {
-							'&:hover': {
-								color: 'white',
-							},
+	${({ disabled }) =>
+		variant({
+			variants: {
+				primary: {
+					border: '1px solid',
+					color: 'white',
+					'@media (hover: hover)': {
+						'&:hover': {
+							color: 'white',
 						},
-					},
-					primaryOutline: {
-						border: '1px solid',
-						background: 'none',
-						'@media (hover: hover)': {
-							'&:hover': {
-								color: disabled ? 'blue2' : 'white',
-							},
-						},
-						'&:active': {
-							color: disabled || 'white',
-						},
-					},
-					primaryTransparent: {
-						border: '1px solid transparent',
-						background: 'none',
-						padding: '0px',
-					},
-					minor: {
-						border: '1px solid',
-						color: disabled ? 'gray22' : 'gray66',
-						'@media (hover: hover)': {
-							'&:hover': {
-								color: disabled ? 'gray22' : 'gray66',
-							},
-						},
-					},
-					minorTransparent: {
-						border: '1px solid transparent',
-						background: 'none',
-						padding: '0px',
 					},
 				},
-			})}
+				primaryOutline: {
+					border: '1px solid',
+					background: 'none',
+					'@media (hover: hover)': {
+						'&:hover': {
+							color: disabled ? 'blue2' : 'white',
+						},
+					},
+					'&:active': {
+						color: disabled || 'white',
+					},
+				},
+				primaryTransparent: {
+					border: '1px solid transparent',
+					background: 'none',
+					padding: '0px',
+				},
+				minor: {
+					border: '1px solid',
+					color: disabled ? 'gray22' : 'gray66',
+					'@media (hover: hover)': {
+						'&:hover': {
+							color: disabled ? 'gray22' : 'gray66',
+						},
+					},
+				},
+				minorTransparent: {
+					border: '1px solid transparent',
+					background: 'none',
+					padding: '0px',
+				},
+			},
+		})}
 
 	${({ variant }) => {
 		switch (variant) {

--- a/components/button/styled.jsx
+++ b/components/button/styled.jsx
@@ -73,7 +73,9 @@ export const Button = styled.button`
 		margin-right: ${props => (props.hasChildren ? '6px' : '')};
 	}
 
-	${({ as: baseTag }) => baseTag && baseTag === 'a' && Anchor};
+	a& {
+		${Anchor}
+	}
 
 	${({ disabled }) =>
 		variant({


### PR DESCRIPTION
Fixes #256, where `AnchorButton` wasn't receiving its anchor-specific styles when used with a wrapped anchor component like [the one in React Router](https://reactrouter.com/web/api/Link).

The solution: changing

```
${({ as: baseTag }) => baseTag && baseTag === 'a' && Anchor};
```

to

```
a& {
	${Anchor}
}
```

inside the style template. Now these special anchor button styles show up in an `a.[class]` section in the compiled stylesheet, which applies if the element in the DOM is an `<a>` no matter what got passed to the `as` prop. 👍🏼

<img width="290" alt="Screen Shot 2020-11-19 at 6 37 54 PM" src="https://user-images.githubusercontent.com/5317080/99741579-84233a80-2a9f-11eb-8112-1554cdabf7a4.png">