### PR TITLE
Add a focus style to Checkbox

### DIFF
--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -55,6 +55,11 @@ export const CheckboxContainer = styled.button`
 
 	&:focus {
 		outline: none;
+
+		& ${CheckboxDiv} {
+			border-color: ${({ theme }) => theme.colors.input.borderFocused};
+			box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.input.shadowFocused};
+		}
 	}
 `;
 

--- a/components/check-box/styled.jsx
+++ b/components/check-box/styled.jsx
@@ -57,8 +57,8 @@ export const CheckboxContainer = styled.button`
 		outline: none;
 
 		& ${CheckboxDiv} {
-			border-color: ${({ theme }) => theme.colors.input.borderFocused};
-			box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.input.shadowFocused};
+			border-color: ${({ theme }) => theme.colors.checkbox.borderFocused};
+			box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.checkbox.shadowFocused};
 		}
 	}
 `;

--- a/theme/core.js
+++ b/theme/core.js
@@ -197,6 +197,8 @@ colors.checkbox = {
 	border: '#95908f',
 	disabledBackground: colors.gray8,
 	disabledBorder: colors.gray22,
+	borderFocused: colors.input.borderFocused,
+	shadowFocused: colors.input.shadowFocused,
 };
 
 colors.datePickerInput = {


### PR DESCRIPTION
I don't have access to the spec referenced in the issue, but how does this look to fix #371?

I grabbed the border color and box shadow straight [from the `Input` component](https://github.com/Faithlife/styled-ui/blob/6043ef87d8d5df05f63915ac24c668abdf22c98f/components/input/Input.jsx#L151-L153). Here's the new focus section of the checkbox styles:

```
&:focus {
	outline: none;

	& ${CheckboxDiv} {
		border-color: ${({ theme }) => theme.colors.input.borderFocused};
		box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.input.shadowFocused};
	}
}
```

And how it looks on the page:

<img width="103" alt="Checkbox in new focus state" src="https://user-images.githubusercontent.com/5317080/99749306-42e55780-2aac-11eb-977d-0489eeadc8f6.png">

Should these values be customized for checkboxes at all, or does it look good as is? If it's fine to leave as is, should the checkbox styles continue referencing [`theme.colors.input`](https://github.com/Faithlife/styled-ui/blob/6043ef87d8d5df05f63915ac24c668abdf22c98f/theme/core.js#L157-L167) directly, or should I create new `borderFocused` and `shadowFocused` fields in [`theme.colors.checkbox`](https://github.com/Faithlife/styled-ui/blob/6043ef87d8d5df05f63915ac24c668abdf22c98f/theme/core.js#L194-L200)?