### PR TITLE
Retrieve selected date period with DatePeriodPicker callback

### DIFF
--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -59,7 +59,7 @@ state: { selectedDateRange: null, selectedDatePeriodName: null }
 ---
 <DatePickerDemo>
 	<div>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</div>
-	<div>The selected date period name is {state.selectedDatePeriodName === undefined ? (<code>undefined</code>) : state.selectedDatePeriodName === null ? (<code>null</code>) : `"${state.selectedDatePeriodName}"`}</div>
+	<div>The selected date period name is {state.selectedDatePeriodName === null ? (<code>null</code>) : `"${state.selectedDatePeriodName}"`}</div>
 	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} style={{ margin: "0.5rem 4rem" }}>Select Dates</Button>

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -55,11 +55,11 @@ state: { selectedDateRange: null }
 
 ```react
 showSource: true
-state: { selectedDateRange: null, selectedDatePeriodName: null }
+state: { selectedDateRange: null, selectedDatePeriodIndex: null }
 ---
 <DatePickerDemo>
 	<div>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</div>
-	<div>The selected date period name is {state.selectedDatePeriodName === null ? (<code>null</code>) : `"${state.selectedDatePeriodName}"`}</div>
+	<div>The selected date period index is <code>{state.selectedDatePeriodIndex === null ? "null" : state.selectedDatePeriodIndex}</code></div>
 	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
 			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} style={{ margin: "0.5rem 4rem" }}>Select Dates</Button>
@@ -67,8 +67,8 @@ state: { selectedDateRange: null, selectedDatePeriodName: null }
 		<Popover isOpen={state.isOpen} placement="bottom" styleOverrides={{ padding: '0px', maxWidth: '1000px' }}>
 			<DatePeriodPicker
 				selectedDateRange={state.selectedDateRange}
-				setSelectedDate={(dateRange, displayName) => {
-					setState({ selectedDateRange: dateRange, selectedDatePeriodName: displayName })
+				setSelectedDate={(dateRange, periodIndex) => {
+					setState({ selectedDateRange: dateRange, selectedDatePeriodIndex: periodIndex })
 				}}
 				dateFunctions={dateFunctions}
 				validate={date => date >= new Date(1970, 0, 1)}

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -55,19 +55,21 @@ state: { selectedDateRange: null }
 
 ```react
 showSource: true
-state: { selectedDateRange: null }
+state: { selectedDateRange: null, selectedDatePeriodName: null }
 ---
 <DatePickerDemo>
-<div>
-	<span style={{ marginRight: '8px' }}>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</span>
+	<div>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</div>
+	<div>The selected date period name is {state.selectedDatePeriodName === undefined ? (<code>undefined</code>) : state.selectedDatePeriodName === null ? (<code>null</code>) : `"${state.selectedDatePeriodName}"`}</div>
 	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
 		<PopoverReference>
-			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>Select Dates</Button>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })} style={{ margin: "0.5rem 4rem" }}>Select Dates</Button>
 		</PopoverReference>
 		<Popover isOpen={state.isOpen} placement="bottom" styleOverrides={{ padding: '0px', maxWidth: '1000px' }}>
 			<DatePeriodPicker
 				selectedDateRange={state.selectedDateRange}
-				setSelectedDate={(dateRange) => setState({ selectedDateRange: dateRange })}
+				setSelectedDate={(dateRange, displayName) => {
+					setState({ selectedDateRange: dateRange, selectedDatePeriodName: displayName })
+				}}
 				dateFunctions={dateFunctions}
 				validate={date => date >= new Date(1970, 0, 1)}
 				parseDate={dateFunctions.parse}
@@ -84,6 +86,5 @@ state: { selectedDateRange: null }
 			/>
 		</Popover>
 	</PopoverManager>
-</div>
 </DatePickerDemo>
 ```

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -30,7 +30,7 @@ export class DatePeriodPicker extends PureComponent {
 		}),
 		/** Function to parse a date of format M/d/yyyy into a date object. See https://date-fns.org/v2.0.0-alpha.25/docs/parse for details */
 		parseDate: PropTypes.func.isRequired,
-		/** A callback that retrieves the currently selected date range and (optionally) the display name of the selected date period whenever the the selected dates change. */
+		/** A callback that retrieves the currently selected date range and (optionally) the index of the selected date period whenever the the selected dates change. */
 		setSelectedDate: PropTypes.func.isRequired,
 		/** Takes a date as a parameter and returns false if that date is invalid */
 		validate: PropTypes.func,

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -30,7 +30,7 @@ export class DatePeriodPicker extends PureComponent {
 		}),
 		/** Function to parse a date of format M/d/yyyy into a date object. See https://date-fns.org/v2.0.0-alpha.25/docs/parse for details */
 		parseDate: PropTypes.func.isRequired,
-		/** A callback accepting the currently selected date range and (optionally) the display name of the selected date period as arguments, which will be called whenever the the selected dates change. */
+		/** A callback that retrieves the currently selected date range and (optionally) the display name of the selected date period whenever the the selected dates change. */
 		setSelectedDate: PropTypes.func.isRequired,
 		/** Takes a date as a parameter and returns false if that date is invalid */
 		validate: PropTypes.func,

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -144,7 +144,7 @@ export class DatePeriodPicker extends PureComponent {
 			<Styled.Container>
 				{datePeriods.map((datePeriod, index) => (
 					<Styled.DatePeriod
-						key={index}
+						key={datePeriod.displayName}
 						onClick={() => {
 							setSelectedDate(datePeriod.dateRange, index);
 						}}

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -104,13 +104,33 @@ export class DatePeriodPicker extends PureComponent {
 				this.setState({ inputValues: { [input]: value } });
 			}
 
-			this.props.setSelectedDate(selectedDate, null);
+			this.props.setSelectedDate(selectedDate, this.getDatePeriodIndex(selectedDate));
 		}
 	}, this.props.debounce);
 
 	handleInputValueChange = (value, input) => {
 		this.setState(state => ({ inputValues: { ...state.inputValues, [input]: value } }));
 		this.parseAndUpdateDate(value, input);
+	};
+
+	getDatePeriodIndex = ({ start, end }) => {
+		if (start === undefined || end === undefined || start === null || end === null) {
+			return null;
+		}
+
+		for (let i = 0; i < this.props.datePeriods.length; i++) {
+			if (
+				isSameDay(start, this.props.datePeriods[i].dateRange.start) &&
+				isSameDay(end, this.props.datePeriods[i].dateRange.end)
+			) {
+				return i;
+			}
+		}
+		return null;
+
+		function isSameDay(date1, date2) {
+			return new Date(date1).setHours(0, 0, 0, 0) === new Date(date2).setHours(0, 0, 0, 0);
+		}
 	};
 
 	render() {
@@ -156,7 +176,9 @@ export class DatePeriodPicker extends PureComponent {
 					<DatePicker
 						asDateRangePicker
 						selectedDateRange={selectedDateRange}
-						setSelectedDate={dateRange => setSelectedDate(dateRange, null)}
+						setSelectedDate={dateRange =>
+							setSelectedDate(dateRange, this.getDatePeriodIndex(dateRange))
+						}
 						validate={validate}
 						dateFunctions={dateFunctions}
 					/>

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -30,7 +30,7 @@ export class DatePeriodPicker extends PureComponent {
 		}),
 		/** Function to parse a date of format M/d/yyyy into a date object. See https://date-fns.org/v2.0.0-alpha.25/docs/parse for details */
 		parseDate: PropTypes.func.isRequired,
-		/** Returns a date when selected. If asDateRangePicker is true, it will return a date range object matching the selectedDateRange prop shape */
+		/** A callback accepting the currently selected date range and (optionally) the display name of the selected date period as arguments, which will be called whenever the the selected dates change. */
 		setSelectedDate: PropTypes.func.isRequired,
 		/** Takes a date as a parameter and returns false if that date is invalid */
 		validate: PropTypes.func,
@@ -126,7 +126,7 @@ export class DatePeriodPicker extends PureComponent {
 					<Styled.DatePeriod
 						key={datePeriod.displayName}
 						onClick={() => {
-							setSelectedDate(datePeriod.dateRange);
+							setSelectedDate(datePeriod.dateRange, datePeriod.displayName);
 						}}
 					>
 						{datePeriod.displayName}

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -122,11 +122,11 @@ export class DatePeriodPicker extends PureComponent {
 
 		return (
 			<Styled.Container>
-				{datePeriods.map(datePeriod => (
+				{datePeriods.map((datePeriod, index) => (
 					<Styled.DatePeriod
-						key={datePeriod.displayName}
+						key={index}
 						onClick={() => {
-							setSelectedDate(datePeriod.dateRange, datePeriod.displayName);
+							setSelectedDate(datePeriod.dateRange, index);
 						}}
 					>
 						{datePeriod.displayName}

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -104,7 +104,7 @@ export class DatePeriodPicker extends PureComponent {
 				this.setState({ inputValues: { [input]: value } });
 			}
 
-			this.props.setSelectedDate(selectedDate);
+			this.props.setSelectedDate(selectedDate, null);
 		}
 	}, this.props.debounce);
 
@@ -156,7 +156,7 @@ export class DatePeriodPicker extends PureComponent {
 					<DatePicker
 						asDateRangePicker
 						selectedDateRange={selectedDateRange}
-						setSelectedDate={setSelectedDate}
+						setSelectedDate={dateRange => setSelectedDate(dateRange, null)}
 						validate={validate}
 						dateFunctions={dateFunctions}
 					/>

--- a/components/date-picker/component.jsx
+++ b/components/date-picker/component.jsx
@@ -46,7 +46,7 @@ export class DatePicker extends Component {
 			start: PropTypes.instanceOf(Date),
 			end: PropTypes.instanceOf(Date),
 		}),
-		/** Returns a date when selected. If asDateRangePicker is true, it will return a date range object matching the selectedDateRange prop shape */
+		/** A callback that retrieves the currently selected date or date range whenever the the selected dates change. */
 		setSelectedDate: PropTypes.func.isRequired,
 		/** Specifies that the component should function as a date range picker */
 		asDateRangePicker: PropTypes.bool,


### PR DESCRIPTION
I have an idea that might close #199. The impression I got from what @rmjohnson wrote is that it'd be convenient if `DatePeriodPicker`'s `setSelectedDate` could have access to the display name of a selected date period, so how does adding a second argument to that callback sound?

I changed the `onClick` prop in `Styled.DatePeriod` to...

```jsx
onClick={() => {
  setSelectedDate(datePeriod.dateRange, datePeriod.displayName);
}}
```

...and now you can add a second argument to your `setSelectedDate` function to capture that display name, like this:

```jsx
setSelectedDate={(dateRange, displayName) => {
  setState({ selectedDateRange: dateRange, selectedDatePeriodName: displayName })
}}
```

And this change won't break anything, because any existing callbacks with one argument won't care if you pass them a second argument—they'll just ignore it.

Here's a demo of [the new version in action](https://tymick.me/styled-ui/#/date-picker/variations?a=date-period-picker-two-argument-callback), and here's a demo of it [with a one-argument callback](https://tymick.me/styled-ui/#/date-picker/variations?a=date-period-picker-one-argument-callback) passed in, to show that it doesn't break.

-----

I also made a big change to the prop description, since when I was first looking at the component, it took me a while to understand that `setSelectedDate` was a callback used to retrieve the selected date when it has been set, not a function to set which date is selected. Here's the new description:

> A callback that retrieves the currently selected date range and (optionally) the display name of the selected date period whenever the the selected dates change.

That may only make things clearer in my own head, though, so let me know if that's too drastic a change and I can scale it back.