### PR TITLE
Add "loading" prop to Button

### DIFF
--- a/catalog/button/variations-v6.md
+++ b/catalog/button/variations-v6.md
@@ -9,34 +9,32 @@ Buttons allow users to command the computer to take some action. Buttons, like a
 ```react
 showSource: true
 ---
-<div>
-	<ButtonDemo>
-		<Button variant="primary" size="medium">
-			Primary
-		</Button>
-		<Button variant="secondary" size="medium">
-			Secondary
-		</Button>
-		<Button variant="minor" size="medium">
-			Minor
-		</Button>
-		<Button variant="transparent" size="medium">
-			Transparent
-		</Button>
-		<Button variant="minorTransparent" size="medium">
-			Minor Transparent
-		</Button>
-		<Button variant="link" size="medium">
-			Link
-		</Button>
-		<Button variant="danger" size="medium">
-			Danger
-		</Button>
-		<Button variant="dangerSpecial" size="medium">
-			Danger (Special)
-		</Button>
-	</ButtonDemo>
-</div>
+<ButtonDemo>
+	<Button variant="primary" size="medium">
+		Primary
+	</Button>
+	<Button variant="secondary" size="medium">
+		Secondary
+	</Button>
+	<Button variant="minor" size="medium">
+		Minor
+	</Button>
+	<Button variant="transparent" size="medium">
+		Transparent
+	</Button>
+	<Button variant="minorTransparent" size="medium">
+		Minor Transparent
+	</Button>
+	<Button variant="link" size="medium">
+		Link
+	</Button>
+	<Button variant="danger" size="medium">
+		Danger
+	</Button>
+	<Button variant="dangerSpecial" size="medium">
+		Danger (Special)
+	</Button>
+</ButtonDemo>
 ```
 
 ### Size
@@ -112,31 +110,61 @@ showSource: true
 ```react
 showSource: true
 ---
-<div>
-	<ButtonDemo>
-		<Button variant="primary" size="medium" disabled>
-			Primary
-		</Button>
-		<Button variant="secondary" size="medium" disabled>
-			Secondary
-		</Button>
-		<Button variant="minor" size="medium" disabled>
-			Minor
-		</Button>
-		<Button variant="transparent" size="medium" disabled>
-			Transparent
-		</Button>
-		<Button variant="link" size="medium" disabled>
-			Link
-		</Button>
-		<Button variant="danger" size="medium" disabled>
-			danger
-		</Button>
-		<Button variant="dangerSpecial" size="medium" disabled>
-			Danger (Special)
-		</Button>
-	</ButtonDemo>
-</div>
+<ButtonDemo>
+	<Button variant="primary" size="medium" disabled>
+		Primary
+	</Button>
+	<Button variant="secondary" size="medium" disabled>
+		Secondary
+	</Button>
+	<Button variant="minor" size="medium" disabled>
+		Minor
+	</Button>
+	<Button variant="transparent" size="medium" disabled>
+		Transparent
+	</Button>
+	<Button variant="link" size="medium" disabled>
+		Link
+	</Button>
+	<Button variant="danger" size="medium" disabled>
+		danger
+	</Button>
+	<Button variant="dangerSpecial" size="medium" disabled>
+		Danger (Special)
+	</Button>
+</ButtonDemo>
+```
+
+## Loading prop
+
+```react
+showSource: true
+state: { loading: false }
+---
+<ButtonDemo>
+	<Button variant="primary" loading={state.loading} onClick={() => {
+		setState({ loading: true });
+		setTimeout(() => setState({ loading: false }), 1000);
+	}}>
+		Primary
+	</Button>
+	<Button variant="secondary" loading={state.loading} onClick={() => {
+		setState({ loading: true });
+		setTimeout(() => setState({ loading: false }), 1000);
+	}}>
+		Secondary
+	</Button>
+	<Button variant="primary" icon={<GearIcon />} loading={state.loading} onClick={() => {
+		setState({ loading: true });
+		setTimeout(() => setState({ loading: false }), 1000);
+	}}>
+		With Icon
+	</Button>
+	<Button variant="transparent" icon={<GearIcon />} loading={state.loading} onClick={() => {
+		setState({ loading: true });
+		setTimeout(() => setState({ loading: false }), 1000);
+	}} />
+</ButtonDemo>
 ```
 
 ## Button Groups
@@ -144,19 +172,17 @@ showSource: true
 ```react
 showSource: true
 ---
-<div>
-	<ButtonDemo>
-		<SegmentedButtonGroup>
-			<Button variant="transparent" active size="medium">
-				Primary
-			</Button>
-			<Button variant="transparent" size="medium">
-				Secondary
-			</Button>
-			<Button variant="transparent" size="medium">
-				Minor
-			</Button>
-		</SegmentedButtonGroup>
-	</ButtonDemo>
-</div>
+<ButtonDemo>
+	<SegmentedButtonGroup>
+		<Button variant="transparent" active size="medium">
+			Primary
+		</Button>
+		<Button variant="transparent" size="medium">
+			Secondary
+		</Button>
+		<Button variant="transparent" size="medium">
+			Minor
+		</Button>
+	</SegmentedButtonGroup>
+</ButtonDemo>
 ```

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -60,6 +60,7 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 	${({ loading }) =>
 		loading
 			? css`
+					color: transparent !important;
 					& > :not(:first-child) {
 						visibility: hidden;
 					}
@@ -95,7 +96,7 @@ const Button = React.forwardRef(({ children, icon, disabled, loading, ...props }
 	>
 		{loading && <LoadingSpinner position="absolute" />}
 		{icon}
-		<div>{children}</div>
+		{children}
 	</ButtonCore>
 ));
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -6,6 +6,7 @@ import { Box } from '../Box';
 import { common, typography } from '../../theme/system';
 import { buttonSizes, buttons } from '../../theme/buttons';
 import { theme } from '../../theme';
+import { LoadingSpinner } from '../loading-spinner';
 
 const sizeVariant = variant({
 	prop: 'size',
@@ -20,6 +21,7 @@ const buttonVariant = variant({
 });
 
 const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'active' : null }))`
+	position: relative;
 	box-sizing: border-box;
 	font-family: inherit;
 	background: transparent;
@@ -55,6 +57,15 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 		margin-right: ${props => (props.hasChildren ? props.theme.space[2] : '')};
 	}
 
+	${({ loading }) =>
+		loading
+			? css`
+					& > :not(:first-child) {
+						visibility: hidden;
+					}
+			  `
+			: ''}
+
 	${sizeVariant}
 	${buttonVariant}
 	${textStyle};
@@ -74,10 +85,17 @@ ButtonCore.defaultProps = {
 	variant: 'primary',
 };
 
-const Button = React.forwardRef(({ children, icon, ...props }, ref) => (
-	<ButtonCore ref={ref} {...props} hasChildren={!!children}>
+const Button = React.forwardRef(({ children, icon, disabled, loading, ...props }, ref) => (
+	<ButtonCore
+		ref={ref}
+		{...props}
+		hasChildren={!!children}
+		loading={loading}
+		disabled={loading || disabled}
+	>
+		{loading && <LoadingSpinner position="absolute" />}
 		{icon}
-		{children}
+		<div>{children}</div>
 	</ButtonCore>
 ));
 

--- a/components/loading-spinner/styled.jsx
+++ b/components/loading-spinner/styled.jsx
@@ -18,7 +18,6 @@ export const Spinner = styled(Box)`
 	border-left-color: ${props => props.overrides.innerColor};
 	border-radius: 50%;
 	display: inline-block;
-	margin-left: 5px;
 	animation: ${spinTransform} 1.1s infinite linear;
 	border-width: 4px;
 


### PR DESCRIPTION
Adds a `loading` prop to Buttons which A. hides the content and shows a loading spinner instead, and B. disables the Button.
Spec: https://app.zeplin.io/project/58a23c2d4597afb248c13a43/screen/5fb5971e1de8db803db4be02

Possible breaking changes:
I had to add `position: relative` to the button. I'm decently confident this won't be an issue, as I can't think of any scenario where a child of a button would be positioned relative to some *ancestor* of the button. Buttons shouldn't typically have particularly complex children anyway, as any child of the button would be part of the click target of the button, so I really don't think there are any reasonable use cases for absolutely positioned children to "escape" the button.

I also had to add a wrapper div around the `{children}` of the button, so that I could do `visibility: hidden` on it. `children` *can* be just a plain string, which would be rendered as a text node, and thus not be styleable without a wrapper element. I don't expect this to break anyone, but it's worth noting.