### PR TITLE
Remove conflicting v6 Button size prop

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -69,15 +69,15 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 
 	${sizeVariant}
 	${buttonVariant}
-	${textStyle};
+	${textStyle}
 
-	${common};
-	${typography};
-	${layout};
-	${flexbox};
-	${position};
-	${border};
-	${background};
+	${common}
+	${typography}
+	${layout}
+	${flexbox}
+	${position}
+	${border}
+	${background}
 `;
 
 ButtonCore.defaultProps = {

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { variant, layout, flexbox, position, textStyle, border, background } from 'styled-system';
+import { variant, flexbox, position, textStyle, border, background } from 'styled-system';
 import 'focus-visible';
 import { Box } from '../Box';
 import { common, typography } from '../../theme/system';
 import { buttonSizes, buttons } from '../../theme/buttons';
 import { theme } from '../../theme';
 import { LoadingSpinner } from '../loading-spinner';
+import layoutExceptSize from '../utils/layout-except-size';
 
 const sizeVariant = variant({
 	prop: 'size',
@@ -73,7 +74,7 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 
 	${common}
 	${typography}
-	${layout}
+	${layoutExceptSize}
 	${flexbox}
 	${position}
 	${border}

--- a/components/utils/layout-except-size.js
+++ b/components/utils/layout-except-size.js
@@ -1,0 +1,52 @@
+/**
+ * A version of Styled System's `layout` utility that leaves out the `size` prop (to avoid conflicts
+ * with other props named `size`).
+ *
+ * Adapted from https://github.com/styled-system/styled-system/blob/92bcdc3c0ff3ec561924e8f8aa793c8a835d0783/packages/layout/src/index.js,
+ * (c) 2017-2018 Brent Jackson, released under the MIT License (https://github.com/styled-system/styled-system/blob/92bcdc3c0ff3ec561924e8f8aa793c8a835d0783/LICENSE.md).
+ */
+
+import { system, get } from 'styled-system';
+
+const isNumber = n => typeof n === 'number' && !isNaN(n);
+const getWidth = (n, scale) => get(scale, n, !isNumber(n) || n > 1 ? n : n * 100 + '%');
+
+const config = {
+	width: {
+		property: 'width',
+		scale: 'sizes',
+		transform: getWidth,
+	},
+	height: {
+		property: 'height',
+		scale: 'sizes',
+	},
+	minWidth: {
+		property: 'minWidth',
+		scale: 'sizes',
+	},
+	minHeight: {
+		property: 'minHeight',
+		scale: 'sizes',
+	},
+	maxWidth: {
+		property: 'maxWidth',
+		scale: 'sizes',
+	},
+	maxHeight: {
+		property: 'maxHeight',
+		scale: 'sizes',
+	},
+	// size: {
+	// 	properties: ['width', 'height'],
+	// 	scale: 'sizes',
+	// },
+	overflow: true,
+	overflowX: true,
+	overflowY: true,
+	display: true,
+	verticalAlign: true,
+};
+
+export const layoutExceptSize = system(config);
+export default layoutExceptSize;


### PR DESCRIPTION
Fixes #393 by creating a [custom style function](https://styled-system.com/api#system) that adds every `layout` prop except `size`, so `Button`'s `size` prop won't block its `width` and `height`.