### PR TITLE
Work around v6 Button size prop bug

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -86,19 +86,41 @@ ButtonCore.defaultProps = {
 	variant: 'primary',
 };
 
-const Button = React.forwardRef(({ children, icon, disabled, loading, ...props }, ref) => (
-	<ButtonCore
-		ref={ref}
-		{...props}
-		hasChildren={!!children}
-		loading={loading}
-		disabled={loading || disabled}
-	>
-		{loading && <LoadingSpinner position="absolute" />}
-		{icon}
-		{children}
-	</ButtonCore>
-));
+const Button = React.forwardRef(
+	({ children, icon, disabled, loading, size, width, height, ...props }, ref) => {
+		// Work around size prop bug (#393)
+		let sizeVariant = ButtonCore.defaultProps.size;
+		let widthStyle = width;
+		let heightStyle = height;
+		if (Object.keys(buttonSizes).includes(size)) {
+			sizeVariant = size;
+		} else if (size !== undefined) {
+			if (width === undefined) {
+				widthStyle = size;
+			}
+			if (height === undefined) {
+				heightStyle = size;
+			}
+		}
+
+		return (
+			<ButtonCore
+				ref={ref}
+				size={sizeVariant}
+				width={widthStyle}
+				height={heightStyle}
+				{...props}
+				hasChildren={!!children}
+				loading={loading}
+				disabled={loading || disabled}
+			>
+				{loading && <LoadingSpinner position="absolute" />}
+				{icon}
+				{children}
+			</ButtonCore>
+		);
+	},
+);
 
 const SegmentedButtonGroup = styled(Box).attrs(({ border }) => ({
 	border: border ?? 1,

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -69,15 +69,15 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 
 	${sizeVariant}
 	${buttonVariant}
-	${textStyle};
+	${textStyle}
 
-	${common};
-	${typography};
-	${layout};
-	${flexbox};
-	${position};
-	${border};
-	${background};
+	${common}
+	${typography}
+	${layout}
+	${flexbox}
+	${position}
+	${border}
+	${background}
 `;
 
 ButtonCore.defaultProps = {

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -88,7 +88,7 @@ ButtonCore.defaultProps = {
 
 const Button = React.forwardRef(
 	({ children, icon, disabled, loading, size, width, height, ...props }, ref) => {
-		// Work around size prop bug (#393)
+		// Temporary workaround for #393
 		let sizeVariant = ButtonCore.defaultProps.size;
 		let widthStyle = width;
 		let heightStyle = height;

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -87,39 +87,30 @@ ButtonCore.defaultProps = {
 };
 
 const Button = React.forwardRef(
-	({ children, icon, disabled, loading, size, width, height, ...props }, ref) => {
-		// Temporary workaround for #393
-		let sizeVariant = ButtonCore.defaultProps.size;
-		let widthStyle = width;
-		let heightStyle = height;
-		if (Object.keys(buttonSizes).includes(size)) {
-			sizeVariant = size;
-		} else if (size !== undefined) {
-			if (width === undefined) {
-				widthStyle = size;
-			}
-			if (height === undefined) {
-				heightStyle = size;
-			}
-		}
-
-		return (
-			<ButtonCore
-				ref={ref}
-				size={sizeVariant}
-				width={widthStyle}
-				height={heightStyle}
-				{...props}
-				hasChildren={!!children}
-				loading={loading}
-				disabled={loading || disabled}
-			>
-				{loading && <LoadingSpinner position="absolute" />}
-				{icon}
-				{children}
-			</ButtonCore>
-		);
-	},
+	(
+		{
+			children,
+			icon,
+			disabled,
+			loading,
+			size = ButtonCore.defaultProps.size, // temporary workaround for #393
+			...props
+		},
+		ref,
+	) => (
+		<ButtonCore
+			ref={ref}
+			size={size}
+			{...props}
+			hasChildren={!!children}
+			loading={loading}
+			disabled={loading || disabled}
+		>
+			{loading && <LoadingSpinner position="absolute" />}
+			{icon}
+			{children}
+		</ButtonCore>
+	),
 );
 
 const SegmentedButtonGroup = styled(Box).attrs(({ border }) => ({


### PR DESCRIPTION
I think this is just a temporary workaround for #393, but I thought of a way to force `ButtonCore` to define `size` before `width` or `height`! And ensure that an attempt to use the Styled System [layout utility](https://styled-system.com/table#layout) `size` doesn't sabotage the size variant logic.

How's this look for the time being?

```js
const Button = React.forwardRef(
  ({ children, icon, disabled, loading, size, width, height, ...props }, ref) => {
    // Temporary workaround for #393
    let sizeVariant = ButtonCore.defaultProps.size;
    let widthStyle = width;
    let heightStyle = height;
    if (Object.keys(buttonSizes).includes(size)) {
      sizeVariant = size;
    } else if (size !== undefined) {
      if (width === undefined) {
        widthStyle = size;
      }
      if (height === undefined) {
        heightStyle = size;
      }
    }

    return (
      <ButtonCore
        ref={ref}
        size={sizeVariant}
        width={widthStyle}
        height={heightStyle}
        {...props}
        hasChildren={!!children}
        loading={loading}
        disabled={loading || disabled}
      >
        {loading && <LoadingSpinner position="absolute" />}
        {icon}
        {children}
      </ButtonCore>
    );
  },
);
```