### PR TITLE
Fix loading prop to not cause react error message

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -57,8 +57,8 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 		margin-right: ${props => (props.hasChildren ? props.theme.space[2] : '')};
 	}
 
-	${({ loading }) =>
-		loading
+	${({ isLoading }) =>
+		isLoading
 			? css`
 					color: transparent !important;
 					& > :not(:first-child) {
@@ -91,7 +91,7 @@ const Button = React.forwardRef(({ children, icon, disabled, loading, ...props }
 		ref={ref}
 		{...props}
 		hasChildren={!!children}
-		loading={loading}
+		isLoading={loading}
 		disabled={loading || disabled}
 	>
 		{loading && <LoadingSpinner position="absolute" />}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5589147/101207536-9d8ebf80-3625-11eb-9da2-7b42e7b805df.png)
It would appear that there's an actual [loading prop](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-loading), so react in dev-mode was throwing an error because the property is not boolean.
That prop has no meaning outside of an iframe, so I see no need to change the outward api, but changed the internal name to avoid the warning.