### PR TITLE
Migrate tooltip to use popover v2

### DIFF
--- a/components/popover/tooltip.jsx
+++ b/components/popover/tooltip.jsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useDebouncedCallback } from '../shared-hooks'; // Copied from react-ui. Import from there when made available.
-import { Popover } from './component';
-import { PopoverManager } from './popover-manager';
-import { PopoverReference } from './popper-helpers';
+import { Popover } from '../popover-v6';
+import { Box } from '../Box';
 
-/** Simple tooltip that uses popovers internally. Does not support custom positioning. */
+/** Simple tooltip that uses popovers internally. */
 export function Tooltip(props) {
+	const ref = useRef();
 	const { children, text, content, isOpen, toggleOnClick, ...otherProps } = props;
 	const [tooltipIsOpen, setToolTipIsOpen] = useState(false);
 	const [isOnMobile, setIsOnMobile] = useState(false);
@@ -27,29 +27,34 @@ export function Tooltip(props) {
 
 	useEffect(() => {
 		setIsOnMobile(window.matchMedia('(hover: none)').matches);
-		return () => {
-			handleMouseLeave.cancel();
-		};
+		return () => handleMouseLeave.cancel();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
+
+	const referenceProps = {
+		onMouseEnter: handleMouseEnter,
+		onMouseLeave: handleMouseLeave,
+		onClick: () => (isOnMobile ? toggle() : setToolTipIsOpen(false)),
+		ref,
+	};
 
 	return isOnMobile && !toggleOnClick ? (
 		children
 	) : (
-		<PopoverManager>
-			<PopoverReference
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
-				onClick={() => {
-					isOnMobile ? toggle() : setToolTipIsOpen(false);
-				}}
-			>
-				{children}
-			</PopoverReference>
-			<Popover {...otherProps} isOpen={tooltipIsOpen || isOpen}>
-				{content || text}
-			</Popover>
-		</PopoverManager>
+		<>
+			{children instanceof Function ? (
+				children(referenceProps)
+			) : (
+				<Box display="inline-block" {...referenceProps}>
+					{children}
+				</Box>
+			)}
+			{(tooltipIsOpen || isOpen) && (
+				<Popover {...otherProps} reference={ref.current}>
+					{content || text}
+				</Popover>
+			)}
+		</>
 	);
 }
 


### PR DESCRIPTION
Migrates tooltips to use the v2 version of poppers.