### PR TITLE
Remove styleOverrides prop from Tab

### DIFF
--- a/components/tabs/tab.jsx
+++ b/components/tabs/tab.jsx
@@ -36,10 +36,6 @@ Tab.propTypes = {
 	disabled: PropTypes.bool,
 };
 
-Tab.defaultProps = {
-	styleOverrides: {},
-};
-
 export function SequencedTab({
 	children,
 	disabled,


### PR DESCRIPTION
Well that was easy! 😁 @RobertBolender was right (#378): `Tab`'s `styleOverrides` prop wasn't even being used.