### PR TITLE
Add ThemeProvider documentation

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -65,6 +65,7 @@ import {
 	AutoSizedRowMasonry,
 	Switch,
 	theme,
+	ThemeProvider,
 } from '../index';
 import {
 	Button as V6Button,
@@ -171,17 +172,31 @@ const pages = [
 		content: pageLoader(() => import('./WELCOME.md')),
 	},
 	{
-		path: '/theme',
 		title: 'Theme',
-		content: pageLoader(() => import('./theme/documentation.md')),
-		imports: {
-			Box,
-			Stack,
-			Text,
-			Paragraph,
-			Heading,
-			ThemeList,
-		},
+		pages: [
+			{
+				path: '/theme/usage',
+				title: 'Usage',
+				content: pageLoader(() => import('./theme/usage.md')),
+				imports: {
+					Box,
+					Stack,
+					Text,
+					Paragraph,
+					Heading,
+					ThemeList,
+				},
+			},
+			{
+				path: '/theme/customization',
+				title: 'Customization',
+				content: pageLoader(() => import('./theme/customization.md')),
+				imports: {
+					ThemeProvider,
+					DocgenTable,
+				},
+			},
+		],
 	},
 	{
 		title: 'Layout Primitives',

--- a/catalog/theme/customization.md
+++ b/catalog/theme/customization.md
@@ -1,0 +1,7 @@
+To customize the global theme, use the `ThemeProvider` wrapper component.
+
+This documentation is automatically generated from JSDoc comments.
+
+```react
+<DocgenTable component={ThemeProvider} />
+```

--- a/catalog/theme/usage.md
+++ b/catalog/theme/usage.md
@@ -1,6 +1,6 @@
 Styled-UI includes a [Styled Components](https://www.styled-components.com/docs/advanced#theming) theme object. The theme is designed to work with [Styled System](https://styled-system.com/theme-specification). Most components accept theme-aware style props that can be used to easily access theme data. When possible, prefer to reference the theme rather than hard code specific color codes, pixel values, font families, etc.
 
-### Spacing scale
+## Spacing scale
 
 Use:
 `<Box paddingX={3}>`
@@ -27,7 +27,7 @@ Use:
 </Box>
 ```
 
-### Color scale
+## Color scale
 
 Use:
 `<Box backgroundColor="blue2">`
@@ -58,7 +58,7 @@ Use:
 </Box>
 ```
 
-### Full theme object
+## Full default Styled UI theme object
 
 ```react
 <Stack spacing={4}>

--- a/components/DefaultThemeProvider.js
+++ b/components/DefaultThemeProvider.js
@@ -1,9 +1,24 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ThemeProvider } from 'styled-components';
 import { theme as defaultTheme } from '../theme';
 
+/**
+ * A wrapper component that injects the default Styled UI theme into the component tree below it if
+ * a global theme has not already been set above it. Otherwise, it simply passes the parent theme
+ * on.
+ */
 export const DefaultThemeProvider = ({ theme, children }) => (
 	<ThemeProvider theme={parentTheme => parentTheme || theme || defaultTheme}>
 		{children}
 	</ThemeProvider>
 );
+
+DefaultThemeProvider.propTypes = {
+	/**
+	 * A theme object to inject instead of the default Styled UI theme if no global theme has already
+	 * been set above it.
+	 */
+	theme: PropTypes.object,
+	children: PropTypes.node,
+};

--- a/components/ThemeProvider.js
+++ b/components/ThemeProvider.js
@@ -1,8 +1,14 @@
 import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import { get } from 'styled-system';
 import { theme as defaultTheme } from '../theme';
 
+/**
+ * A wrapper component that merges a provided theme object with the existing global theme above it
+ * (or the default Styled UI theme if no global theme has been set) and provides the resulting new
+ * global theme prop to all styled-components underneath it via the context API.
+ */
 export function ThemeProvider({ theme, children }) {
 	const getCurrentTheme = useCallback(parent => getTheme(getTheme(parent ?? defaultTheme, theme)), [
 		theme,
@@ -10,6 +16,11 @@ export function ThemeProvider({ theme, children }) {
 
 	return <StyledThemeProvider theme={getCurrentTheme}>{children}</StyledThemeProvider>;
 }
+
+ThemeProvider.propTypes = {
+	theme: PropTypes.object.isRequired,
+	children: PropTypes.node,
+};
 
 function getTheme(parent, overrides) {
 	if (!overrides) {


### PR DESCRIPTION
Not a direct v6 need, but as I was adding `Radio`'s changes to the upgrade guide in #416, I thought it'd be nice to be able to point to documentation for the [`ThemeProvider`](https://github.com/Faithlife/styled-ui/blob/cd0e7ce673095811ceb73401aceb4865e332b0ce/components/ThemeProvider.js) component, since the old `theme` prop had gone away (which should make it useful for other components as well). So this PR moves the current page at `/theme` to `/theme/usage` and adds a [new `ThemeProvider` documentation page](https://deploy-preview-419--faithlife-styled-ui.netlify.app/#/theme/customization) at `/theme/customization`. How's that sound?