### PR TITLE
Add SimpleToast and Slider changes to upgrade guide

### DIFF
--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -9,3 +9,7 @@
   - Check your sizes, standalone props have been replaced by the `size` prop, such as `size=medium` instead of `medium`.
 - `Modal`
   - Subcomponents have been renamed, `ModalContent` has been replaced by `Modal.Content`, etc.
+- `SimpleToast`
+  - The `styleOverrides` prop and old `theme` prop have been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+- `Slider`
+  - The `styleOverrides` prop has been removed in favor of Styled System props.


### PR DESCRIPTION
Following up on #400 and #404, I've added those components' changes to the upgrade guide.