### PR TITLE
Check date periods for duplicate display names in DatePeriodPicker

### DIFF
--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -120,7 +120,7 @@ export class DatePeriodPicker extends PureComponent {
 	 * Gets the index of a passed date period that happens to match a manually selected date range, if
 	 * one matches.
 	 * @param {{ start: Date, end: Date }} dateRange - The manually selected start and end dates.
-	 * @return {number | null} The index of a matching date period or `null` if no period matches.
+	 * @return {number | null} The original array index of a matching date period or `null` if no period matches.
 	 */
 	getDatePeriodIndex = ({ start, end }) => {
 		if (start === undefined || end === undefined || start === null || end === null) {
@@ -132,7 +132,7 @@ export class DatePeriodPicker extends PureComponent {
 				isSameDay(start, datePeriod.dateRange.start) &&
 				isSameDay(end, datePeriod.dateRange.end)
 			) {
-				return datePeriod.index;
+				return datePeriod.originalIndex;
 			}
 		}
 
@@ -150,9 +150,9 @@ export class DatePeriodPicker extends PureComponent {
 
 	/**
 	 * Returns only the first date period of each display name, retaining the original array index in
-	 * a new `index` property. Also sends a console warning in development environments when
+	 * a new `originalIndex` property. Also sends a console warning in development environments when
 	 * duplicates are passed.
-	 * @returns {Array<{ index: number; displayName: string; dateRange: { start: Date; end: Date } }}
+	 * @returns {Array<{ displayName: string; dateRange: { start: Date; end: Date }; originalIndex: number}}
 	 */
 	getUniqueDatePeriods = () => {
 		const uniqueDatePeriods = [];
@@ -172,7 +172,7 @@ export class DatePeriodPicker extends PureComponent {
 				}
 			} else {
 				// Display name is unique: add period to return array (and save original index)
-				uniqueDatePeriods.push({ ...currentPeriod, index: i });
+				uniqueDatePeriods.push({ ...currentPeriod, originalIndex: i });
 			}
 		}
 
@@ -188,11 +188,11 @@ export class DatePeriodPicker extends PureComponent {
 
 		return (
 			<Styled.Container>
-				{this.getUniqueDatePeriods().map(({ index, displayName, dateRange }) => (
+				{this.getUniqueDatePeriods().map(({ displayName, dateRange, originalIndex }) => (
 					<Styled.DatePeriod
 						key={displayName}
 						onClick={() => {
-							setSelectedDate(dateRange, index);
+							setSelectedDate(dateRange, originalIndex);
 						}}
 					>
 						{displayName}

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -18,8 +18,8 @@ export class DatePeriodPicker extends PureComponent {
 			PropTypes.shape({
 				displayName: PropTypes.string.isRequired,
 				dateRange: PropTypes.shape({
-					start: PropTypes.instanceOf(Date).isRequired,
-					end: PropTypes.instanceOf(Date).isRequired,
+					start: PropTypes.instanceOf(Date),
+					end: PropTypes.instanceOf(Date),
 				}).isRequired,
 			}),
 		).isRequired,

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -159,9 +159,16 @@ export class DatePeriodPicker extends PureComponent {
 
 		for (let i = 0; i < this.props.datePeriods.length; i++) {
 			const currentPeriod = this.props.datePeriods[i];
-			const uniqueDisplayNames = uniqueDatePeriods.map(({ displayName }) => displayName);
 
-			if (uniqueDisplayNames.includes(currentPeriod.displayName)) {
+			if (
+				uniqueDatePeriods.find(
+					datePeriod => datePeriod.displayName === currentPeriod.displayName,
+				) === undefined
+			) {
+				// Display name is unique: add period to return array (and save original index)
+				uniqueDatePeriods.push({ ...currentPeriod, index: i });
+			} else {
+				// Display name is a duplicate: filter out and warn the dev
 				if (process.env.NODE_ENV !== 'production') {
 					console.warn(
 						`A \`DatePeriodPicker\` has been passed multiple date periods named "${
@@ -169,8 +176,6 @@ export class DatePeriodPicker extends PureComponent {
 						}". Only the first "${currentPeriod.displayName}" period has been passed.`,
 					);
 				}
-			} else {
-				uniqueDatePeriods.push(Object.assign({ index: i }, currentPeriod));
 			}
 		}
 

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -159,15 +159,9 @@ export class DatePeriodPicker extends PureComponent {
 
 		for (let i = 0; i < this.props.datePeriods.length; i++) {
 			const currentPeriod = this.props.datePeriods[i];
+			const uniqueDisplayNames = uniqueDatePeriods.map(({ displayName }) => displayName);
 
-			if (
-				uniqueDatePeriods.find(
-					datePeriod => datePeriod.displayName === currentPeriod.displayName,
-				) === undefined
-			) {
-				// Display name is unique: add period to return array (and save original index)
-				uniqueDatePeriods.push({ ...currentPeriod, index: i });
-			} else {
+			if (uniqueDisplayNames.includes(currentPeriod.displayName)) {
 				// Display name is a duplicate: filter out and warn the dev
 				if (process.env.NODE_ENV !== 'production') {
 					console.warn(
@@ -176,6 +170,9 @@ export class DatePeriodPicker extends PureComponent {
 						}". Only the first "${currentPeriod.displayName}" period has been passed.`,
 					);
 				}
+			} else {
+				// Display name is unique: add period to return array (and save original index)
+				uniqueDatePeriods.push({ ...currentPeriod, index: i });
 			}
 		}
 

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -113,28 +113,69 @@ export class DatePeriodPicker extends PureComponent {
 		this.parseAndUpdateDate(value, input);
 	};
 
+	/**
+	 * Gets the index of a passed date period that happens to match a manually selected date range, if
+	 * one matches.
+	 * @param {{ start: Date, end: Date }} dateRange - The manually selected start and end dates.
+	 * @return {number | null} The index of a matching date period or `null` if no period matches.
+	 */
 	getDatePeriodIndex = ({ start, end }) => {
 		if (start === undefined || end === undefined || start === null || end === null) {
 			return null;
 		}
 
-		for (let i = 0; i < this.props.datePeriods.length; i++) {
+		for (const datePeriod of this.getUniqueDatePeriods()) {
 			if (
-				isSameDay(start, this.props.datePeriods[i].dateRange.start) &&
-				isSameDay(end, this.props.datePeriods[i].dateRange.end)
+				isSameDay(start, datePeriod.dateRange.start) &&
+				isSameDay(end, datePeriod.dateRange.end)
 			) {
-				return i;
+				return datePeriod.index;
 			}
 		}
+
 		return null;
 
+		/**
+		 * @param {Date} date1
+		 * @param {Date} date2
+		 * @returns {boolean}
+		 */
 		function isSameDay(date1, date2) {
 			return new Date(date1).setHours(0, 0, 0, 0) === new Date(date2).setHours(0, 0, 0, 0);
 		}
 	};
 
+	/**
+	 * Returns only the first date period of each display name, retaining the original array index in
+	 * a new `index` property. Also sends a console warning in development environments when
+	 * duplicates are passed.
+	 * @returns {Array<{ index: number; displayName: string; dateRange: { start: Date; end: Date } }}
+	 */
+	getUniqueDatePeriods = () => {
+		const uniqueDatePeriods = [];
+
+		for (let i = 0; i < this.props.datePeriods.length; i++) {
+			const currentPeriod = this.props.datePeriods[i];
+			const uniqueDisplayNames = uniqueDatePeriods.map(({ displayName }) => displayName);
+
+			if (uniqueDisplayNames.includes(currentPeriod.displayName)) {
+				if (process.env.NODE_ENV !== 'production') {
+					console.warn(
+						`A \`DatePeriodPicker\` has been passed multiple date periods named "${
+							currentPeriod.displayName
+						}". Only the first "${currentPeriod.displayName}" period has been passed.`,
+					);
+				}
+			} else {
+				uniqueDatePeriods.push(Object.assign({ index: i }, currentPeriod));
+			}
+		}
+
+		return uniqueDatePeriods;
+	};
+
 	render() {
-		const { setSelectedDate, validate, dateFunctions, datePeriods } = this.props;
+		const { setSelectedDate, validate, dateFunctions } = this.props;
 		const {
 			inputValues: { start, end },
 			selectedDateRange,
@@ -142,14 +183,14 @@ export class DatePeriodPicker extends PureComponent {
 
 		return (
 			<Styled.Container>
-				{datePeriods.map((datePeriod, index) => (
+				{this.getUniqueDatePeriods().map(({ index, displayName, dateRange }) => (
 					<Styled.DatePeriod
-						key={datePeriod.displayName}
+						key={displayName}
 						onClick={() => {
-							setSelectedDate(datePeriod.dateRange, index);
+							setSelectedDate(dateRange, index);
 						}}
 					>
-						{datePeriod.displayName}
+						{displayName}
 					</Styled.DatePeriod>
 				))}
 				<Styled.DateInputContainer>

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -30,7 +30,10 @@ export class DatePeriodPicker extends PureComponent {
 		}),
 		/** Function to parse a date of format M/d/yyyy into a date object. See https://date-fns.org/v2.0.0-alpha.25/docs/parse for details */
 		parseDate: PropTypes.func.isRequired,
-		/** A callback that retrieves the currently selected date range and (optionally) the index of the selected date period whenever the the selected dates change. */
+		/**
+		 * A callback that retrieves the currently selected date range and (optionally) the index of the selected date period whenever the the selected dates change.
+		 * @type {(dateRange: { start: Date, end: Date }, index?: number) => void}
+		 */
 		setSelectedDate: PropTypes.func.isRequired,
 		/** Takes a date as a parameter and returns false if that date is invalid */
 		validate: PropTypes.func,

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -21,7 +21,7 @@ export class DatePeriodPicker extends PureComponent {
 					start: PropTypes.instanceOf(Date),
 					end: PropTypes.instanceOf(Date),
 				}).isRequired,
-			}),
+			}).isRequired,
 		).isRequired,
 		/** Sets the selected date range */
 		selectedDateRange: PropTypes.shape({

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -18,9 +18,9 @@ export class DatePeriodPicker extends PureComponent {
 			PropTypes.shape({
 				displayName: PropTypes.string.isRequired,
 				dateRange: PropTypes.shape({
-					start: PropTypes.instanceOf(Date),
-					end: PropTypes.instanceOf(Date),
-				}),
+					start: PropTypes.instanceOf(Date).isRequired,
+					end: PropTypes.instanceOf(Date).isRequired,
+				}).isRequired,
 			}),
 		).isRequired,
 		/** Sets the selected date range */


### PR DESCRIPTION
Resolves #423.

I added a new method called `getUniqueDatePeriods` that returns only the first date period of each display name, retaining the original array index in a new `index` property. It also sends a console warning in development environments when duplicates are passed. The `render` and `getDatePeriodIndex` methods now call this method instead of using `this.props.datePeriods`.

While I was at it, I also made `dateRange` and its `start` and `end` properties required in the prop type for `datePeriods`. I figured that was the intent already (that all passed date periods have date ranges, not just names), but if that's not the case I can change it back. 👍🏼