### PR TITLE
Fix min/max date focus-away.

### DIFF
--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -24,6 +24,34 @@ state: { selectedDate: null }
 </DatePickerDemo>
 ```
 
+## With Min and Max Dates
+
+```react
+showSource: true
+state: { selectedDate: null }
+---
+<DatePickerDemo>
+<div>
+<span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
+	<PopoverManager onFocusAway={() => setState({ isOpen: false })}>
+		<PopoverReference>
+			<Button variant="primary" size="medium" onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
+		</PopoverReference>
+		<Popover isOpen={state.isOpen} placement="bottom" styleOverrides={{ maxWidth: '1000px' }}>
+			<DatePicker
+				selectedDate={state.selectedDate}
+				minDate={new Date(today.getTime()).setMonth(today.getMonth() - 2)}
+				maxDate={new Date(today.getTime()).setMonth(today.getMonth() + 2)}
+				setSelectedDate={(date) => setState({ selectedDate: date })}
+				dateFunctions={dateFunctions}
+				validate={() => true}
+			/>
+		</Popover>
+	</PopoverManager>
+</div>
+</DatePickerDemo>
+```
+
 ## Default Date Range Picker
 
 ```react

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -453,6 +453,7 @@ const pages = [
 					`,
 					DatePicker,
 					DatePeriodPicker,
+					today: new Date(),
 					dateFunctions: {
 						...dateFunctions,
 					},

--- a/components/date-picker/component.jsx
+++ b/components/date-picker/component.jsx
@@ -89,11 +89,19 @@ export class DatePicker extends Component {
 		}
 	};
 
-	decrementMonth = () =>
+	decrementMonth = () => {
+		if (!this.canDecrementMonth(this.state.weeks)) {
+			return;
+		}
 		this.setMonth(this.props.dateFunctions.subMonths(this.state.currentMonth, 1));
+	};
 
-	incrementMonth = () =>
+	incrementMonth = () => {
+		if (!this.canIncrementMonth(this.state.weeks)) {
+			return;
+		}
 		this.setMonth(this.props.dateFunctions.addMonths(this.state.currentMonth, 1));
+	};
 
 	canDecrementMonth = weeks => {
 		const firstDay = weeks[0][0];
@@ -122,8 +130,8 @@ export class DatePicker extends Component {
 				<Styled.Header>
 					<Styled.ChangeMonth
 						onClick={this.decrementMonth}
-						disabled={!this.canDecrementMonth(weeks)}
-						tabIndex="-1"
+						visuallyDisabled={!this.canDecrementMonth(weeks)}
+						tabIndex="0"
 					>
 						<Caret
 							style={{
@@ -137,8 +145,8 @@ export class DatePicker extends Component {
 					<Styled.MonthLabel>{dateFunctions.format(currentMonth, 'MMMM yyyy')}</Styled.MonthLabel>
 					<Styled.ChangeMonth
 						onClick={this.incrementMonth}
-						disabled={!this.canIncrementMonth(weeks)}
-						tabIndex="-1"
+						visuallyDisabled={!this.canIncrementMonth(weeks)}
+						tabIndex="0"
 					>
 						<Caret
 							style={{

--- a/components/date-picker/styled.jsx
+++ b/components/date-picker/styled.jsx
@@ -12,6 +12,10 @@ export const ChangeMonth = styled.button`
 	width: 22px;
 	background: none;
 	cursor: pointer;
+
+	&:focus {
+		outline: ${({ visuallyDisabled }) => visuallyDisabled && `${colors.gray22} auto 1px`};
+	}
 `;
 
 export const Header = styled.div`


### PR DESCRIPTION
Default browser behavior is to set the document.activeElement to the body
when a previously-focused button becomes programmatically disabled.
Our default focus-away handler on the DatePicker was then closing the
picker immediately after navigating to a month which disabled the active
navigation button.

This PR also makes the DatePicker ever so slightly more navigable with a
keyboard, allowing those buttons to be focused. I'm sure there are
additional ways we can make this component more ARIA-compliant, but I
propose that this first step is at least no worse than before.

Resolves https://faithlife.atlassian.net/browse/SUI-1