### PR TITLE
Update theme object URL in upgrade guide

### DIFF
--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -10,22 +10,22 @@
   - Check your variants, `primaryOutline` has been replaced by `secondary`.
   - Check your sizes, standalone props have been replaced by the `size` prop, such as `size=medium` instead of `medium`.
 - `Checkbox`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `DatePickerInput`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for the input directly on the `DatePickerInput` component, and use style props for the calendar popover on a `DatePickerInput.Popover` child config component.
   - The `placement` prop has been removed—use `placement` on `DatePickerInput.Popover` instead.
 - `HelpBox`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `Input`
   - The `styleOverrides` prop has been removed in favor of Styled System props.
 - `LoadingSpinner`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `Modal`
   - Subcomponents have been renamed, `ModalContent` has been replaced by `Modal.Content`, etc.
 - `Radio`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `SimpleToast`
-  - The `styleOverrides` prop and old `theme` prop have been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
+  - The `styleOverrides` prop and old `theme` prop have been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `Slider`
   - The `styleOverrides` prop has been removed in favor of Styled System props.
 - `Tab`

--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -10,22 +10,22 @@
   - Check your variants, `primaryOutline` has been replaced by `secondary`.
   - Check your sizes, standalone props have been replaced by the `size` prop, such as `size=medium` instead of `medium`.
 - `Checkbox`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
 - `DatePickerInput`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for the input directly on the `DatePickerInput` component, and use style props for the calendar popover on a `DatePickerInput.Popover` child config component.
   - The `placement` prop has been removed—use `placement` on `DatePickerInput.Popover` instead.
 - `HelpBox`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
 - `Input`
   - The `styleOverrides` prop has been removed in favor of Styled System props.
 - `LoadingSpinner`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
 - `Modal`
   - Subcomponents have been renamed, `ModalContent` has been replaced by `Modal.Content`, etc.
 - `Radio`
-  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+  - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
 - `SimpleToast`
-  - The `styleOverrides` prop and old `theme` prop have been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme) and Styled System props.
+  - The `styleOverrides` prop and old `theme` prop have been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props.
 - `Slider`
   - The `styleOverrides` prop has been removed in favor of Styled System props.
 - `Tab`


### PR DESCRIPTION
Quick follow-up to #419.

`UpgradeGuide.md` mentions the global theme object several times, linking to the Catalog [Theme page](https://faithlife.github.io/styled-ui/#/theme) for instructions on how to use this theme API instead of an old `theme` prop. #419 moved `/theme` to `/theme/usage` and added documentation for the `ThemeProvider` component to a new page at `/theme/customization`.