### PR TITLE
Add height 100% to fix Safari modals.

### DIFF
--- a/components/modal/modal-content.jsx
+++ b/components/modal/modal-content.jsx
@@ -10,6 +10,7 @@ export const ModalContent = ({ paddingY, maxHeight, children, ...props }) => {
 	return (
 		<ThemedBox
 			paddingY={paddingY ?? contentPadding}
+			height="100%"
 			maxHeight={maxHeight ? maxHeight : fullscreen ? '100vh' : 'calc(100vh - 150px)'}
 		>
 			<Box


### PR DESCRIPTION
> Safari sees this as a missing link, which it considers a violation of the spec, which essentially says:
> The parent of an element with a percentage height must have a defined height and it must be with the height property. Otherwise, the element with a percentage height must default to height: auto (content height).
> https://stackoverflow.com/a/43421645/9727796