### PR TITLE
Add common/typography Styled System props to v6 components

### DIFF
--- a/components/accordion/accordion-header.jsx
+++ b/components/accordion/accordion-header.jsx
@@ -5,6 +5,7 @@ import { Text } from '../Text';
 import { Box } from '../Box';
 import { UtilityButton } from '../button';
 import { ChevronRight, ChevronDown } from '../icons/12px';
+import { typography } from '../../theme/system';
 import { useAccordionContext, useAccordionItemContext } from './accordion-util';
 
 export function AccordionHeader({
@@ -56,7 +57,7 @@ export function AccordionHeader({
 	}, [headerId, focusableChildList]);
 
 	return (
-		<Box
+		<HeaderBox
 			display="flex"
 			gridArea="header"
 			borderTop={1}
@@ -117,7 +118,7 @@ export function AccordionHeader({
 					{renderCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
 				</Box>
 			) : null}
-		</Box>
+		</HeaderBox>
 	);
 }
 
@@ -131,7 +132,10 @@ AccordionHeader.propTypes = {
 	/** Receives an isExpanded boolean value. */
 	renderCustomIndicator: PropTypes.func,
 	...Box.propTypes,
+	...typography.propTypes,
 };
+
+const HeaderBox = styled(Box)(typography);
 
 const Heading = styled.header.attrs(({ ariaLevel }) => ({
 	role: 'heading',

--- a/components/accordion/accordion-item.jsx
+++ b/components/accordion/accordion-item.jsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useId } from '../shared-hooks';
 import { Box } from '../Box';
+import { typography } from '../../theme/system';
 import { useAccordionContext, AccordionItemContextProvider } from './accordion-util';
 
-export function AccordionItem({ children, index, pinned: isPinned }) {
+export function AccordionItem({ children, index, pinned: isPinned, ...otherProps }) {
 	const { expandedSections, onExpansion } = useAccordionContext();
 
 	const isExpanded = expandedSections.includes(index);
@@ -29,15 +31,16 @@ export function AccordionItem({ children, index, pinned: isPinned }) {
 	);
 
 	return (
-		<Box
+		<ItemBox
 			display="grid"
 			gridTemplateAreas={`
 				'header'
 				'panel'
 			`}
+			{...otherProps}
 		>
 			<AccordionItemContextProvider value={context}>{children}</AccordionItemContextProvider>
-		</Box>
+		</ItemBox>
 	);
 }
 
@@ -48,4 +51,8 @@ AccordionItem.propTypes = {
 	index: PropTypes.number,
 	/** If `true`, the item will remain permanenty expanded. */
 	pinned: PropTypes.bool,
+	...Box.propTypes,
+	...typography.propTypes,
 };
+
+const ItemBox = styled(Box)(typography);

--- a/components/accordion/accordion-item.jsx
+++ b/components/accordion/accordion-item.jsx
@@ -46,4 +46,6 @@ AccordionItem.propTypes = {
 	children: PropTypes.node.isRequired,
 	/** This is supplied by the Accordion component. */
 	index: PropTypes.number,
+	/** If `true`, the item will remain permanenty expanded. */
+	pinned: PropTypes.bool,
 };

--- a/components/accordion/accordion-panel.jsx
+++ b/components/accordion/accordion-panel.jsx
@@ -6,6 +6,7 @@ import { Collapse } from '../collapse';
 import { Box } from '../Box';
 import { useAccordionItemContext } from './accordion-util';
 import { useAccordionContext } from './accordion-util';
+import { typography } from '../../theme/system';
 
 export function AccordionPanel({ children, mountOnEnter, unmountOnExit, ...props }) {
 	const ctx = useAccordionContext();
@@ -32,6 +33,7 @@ AccordionPanel.propTypes = {
 	/** true if panel contents should be unmounted when the section is closed **/
 	unmountOnExit: PropTypes.bool,
 	...Box.propTypes,
+	...typography.propTypes,
 };
 
 export const Panel = styled(Box).attrs(({ headerId, panelId }) => ({
@@ -51,4 +53,5 @@ export const Panel = styled(Box).attrs(({ headerId, panelId }) => ({
 			},
 		},
 	}),
+	typography,
 );

--- a/components/accordion/accordion.jsx
+++ b/components/accordion/accordion.jsx
@@ -5,6 +5,7 @@ import { system } from 'styled-system';
 import { propType as styledPropType } from '@styled-system/prop-types';
 import { Box } from '../Box';
 import { useKeyboardNav, AccordionContextProvider } from './accordion-util';
+import { typography } from '../../theme/system';
 import { Panel } from './accordion-panel';
 
 export function Accordion({
@@ -95,6 +96,7 @@ Accordion.propTypes = {
 	/** Overrides the `padding` style on all nested `Accordion.Panel`s */
 	panelPadding: styledPropType,
 	...Box.propTypes,
+	...typography.propTypes,
 };
 
 const AccordionBox = styled(Box)`
@@ -106,4 +108,6 @@ const AccordionBox = styled(Box)`
 			},
 		})}
 	}
+
+	${typography}
 `;


### PR DESCRIPTION
I'm running through and adding [`common`](https://github.com/Faithlife/styled-ui/blob/1e0c8465be657e65e3541fb895507c4b8ea85b5e/theme/system.js#L16-L34) and (when appropriate) [`typography`](https://github.com/Faithlife/styled-ui/blob/1e0c8465be657e65e3541fb895507c4b8ea85b5e/theme/system.js#L36-L50) Styled System props to components as per [this comment](https://github.com/Faithlife/styled-ui/issues/378#issuecomment-749862700) on #378. Started with Accordion and I'm going to continue down alphabetically. 👍🏼