### PR TITLE
Finish removing styleOverrides prop from Input

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -112,8 +112,7 @@ Input.propTypes = {
 export { Input };
 
 const StyledInput = styled.input(
-	/** @todo Remove styleOverrides for v6 release. */
-	({ theme, variant, styleOverrides = {} }) => css`
+	({ theme, variant }) => css`
 		${resetStyles}
 		${textStyle}
 
@@ -127,16 +126,6 @@ const StyledInput = styled.input(
 		color: ${theme.colors.input.foreground};
 
 		${system({ resize: true })}
-
-		${'height' in styleOverrides &&
-			css`
-				height: ${styleOverrides.height};
-			`}
-
-		${'width' in styleOverrides &&
-			css`
-				width: ${styleOverrides.width};
-			`}
 
 		box-shadow: none;
 

--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -112,7 +112,7 @@ Input.propTypes = {
 export { Input };
 
 const StyledInput = styled.input(
-	({ theme, variant }) => css`
+	({ theme }) => css`
 		${resetStyles}
 		${textStyle}
 


### PR DESCRIPTION
Just noticed I left a `@todo` note for myself to remove something after v6 release.