### PR TITLE
Select all text on focus by default in NumberInput

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -100,6 +100,10 @@ Input.propTypes = {
 	/** Large variation (deprecated in favor of the variant prop) */
 	large: PropTypes.bool,
 	size: PropTypes.number,
+	/**
+	 * Whether focusing the input should select _all_ of its text, regardless of where it was clicked.
+	 */
+	selectOnFocus: PropTypes.bool,
 	/** Textarea input variation */
 	textarea: PropTypes.bool,
 	...common.propTypes,

--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -74,6 +74,7 @@ const NumberInput = React.memo(
 );
 
 NumberInput.defaultProps = {
+	selectOnFocus: true,
 	theme,
 };
 


### PR DESCRIPTION
Resolves [FLCOM-6239](https://faithlife.atlassian.net/browse/FLCOM-6239), where it was requested that all number inputs select all text on focus by default. More discussion with @AuresaNyctea in the comments in Jira.

Seems like a breaking change, but... should it be considered a "bug fix" since we want this functionality across the entire product line? ¯\_(ツ)_/¯