### PR TITLE
More Flexible date period picker

### DIFF
--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -40,6 +40,7 @@ export class DatePeriodPicker extends PureComponent {
 		dateFunctions: dateFunctionProps,
 		/** Debounce value for date inputs. Defaults to 500ms */
 		debounce: PropTypes.number,
+		disableCustomRange: PropTypes.bool,
 		disableCalendar: PropTypes.bool,
 	};
 
@@ -181,7 +182,13 @@ export class DatePeriodPicker extends PureComponent {
 	};
 
 	render() {
-		const { setSelectedDate, validate, dateFunctions, disableCalendar } = this.props;
+		const {
+			setSelectedDate,
+			validate,
+			dateFunctions,
+			disableCustomRange,
+			disableCalendar,
+		} = this.props;
 		const {
 			inputValues: { start, end },
 			selectedDateRange,
@@ -199,26 +206,28 @@ export class DatePeriodPicker extends PureComponent {
 						{displayName}
 					</Styled.DatePeriod>
 				))}
-				<Styled.DateInputContainer>
-					<Styled.Label>
-						<Styled.LabelText>From</Styled.LabelText>
-						<Input
-							placeholder="mm/dd/yyyy"
-							value={start}
-							onChange={event => this.handleInputValueChange(event.target.value, 'start')}
-							small
-						/>
-					</Styled.Label>
-					<Styled.Label>
-						<Styled.LabelText>To</Styled.LabelText>
-						<Input
-							placeholder="mm/dd/yyyy"
-							value={end}
-							onChange={event => this.handleInputValueChange(event.target.value, 'end')}
-							small
-						/>
-					</Styled.Label>
-				</Styled.DateInputContainer>
+				{disableCustomRange ? null : (
+					<Styled.DateInputContainer>
+						<Styled.Label>
+							<Styled.LabelText>From</Styled.LabelText>
+							<Input
+								placeholder="mm/dd/yyyy"
+								value={start}
+								onChange={event => this.handleInputValueChange(event.target.value, 'start')}
+								small
+							/>
+						</Styled.Label>
+						<Styled.Label>
+							<Styled.LabelText>To</Styled.LabelText>
+							<Input
+								placeholder="mm/dd/yyyy"
+								value={end}
+								onChange={event => this.handleInputValueChange(event.target.value, 'end')}
+								small
+							/>
+						</Styled.Label>
+					</Styled.DateInputContainer>
+				)}
 				{disableCalendar ? null : (
 					<Styled.DatePickerContainer>
 						<DatePicker

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -40,6 +40,7 @@ export class DatePeriodPicker extends PureComponent {
 		dateFunctions: dateFunctionProps,
 		/** Debounce value for date inputs. Defaults to 500ms */
 		debounce: PropTypes.number,
+		disableEnumeratedRanges: PropTypes.bool,
 		disableCustomRange: PropTypes.bool,
 		disableCalendar: PropTypes.bool,
 	};
@@ -186,6 +187,7 @@ export class DatePeriodPicker extends PureComponent {
 			setSelectedDate,
 			validate,
 			dateFunctions,
+			disableEnumeratedRanges,
 			disableCustomRange,
 			disableCalendar,
 		} = this.props;
@@ -196,16 +198,18 @@ export class DatePeriodPicker extends PureComponent {
 
 		return (
 			<Styled.Container>
-				{this.getUniqueDatePeriods().map(({ displayName, dateRange, originalIndex }) => (
-					<Styled.DatePeriod
-						key={displayName}
-						onClick={() => {
-							setSelectedDate(dateRange, originalIndex);
-						}}
-					>
-						{displayName}
-					</Styled.DatePeriod>
-				))}
+				{disableEnumeratedRanges
+					? null
+					: this.getUniqueDatePeriods().map(({ displayName, dateRange, originalIndex }) => (
+							<Styled.DatePeriod
+								key={displayName}
+								onClick={() => {
+									setSelectedDate(dateRange, originalIndex);
+								}}
+							>
+								{displayName}
+							</Styled.DatePeriod>
+					  ))}
 				{disableCustomRange ? null : (
 					<Styled.DateInputContainer>
 						<Styled.Label>

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -43,6 +43,7 @@ export class DatePeriodPicker extends PureComponent {
 		disableEnumeratedRanges: PropTypes.bool,
 		disableCustomRange: PropTypes.bool,
 		disableCalendar: PropTypes.bool,
+		disableInferredDatePeriodIndex: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -110,7 +111,10 @@ export class DatePeriodPicker extends PureComponent {
 				this.setState({ inputValues: { [input]: value } });
 			}
 
-			this.props.setSelectedDate(selectedDate, this.getDatePeriodIndex(selectedDate));
+			this.props.setSelectedDate(
+				selectedDate,
+				this.props.disableInferredDatePeriodIndex ? null : this.getDatePeriodIndex(selectedDate),
+			);
 		}
 	}, this.props.debounce);
 
@@ -190,6 +194,7 @@ export class DatePeriodPicker extends PureComponent {
 			disableEnumeratedRanges,
 			disableCustomRange,
 			disableCalendar,
+			disableInferredDatePeriodIndex,
 		} = this.props;
 		const {
 			inputValues: { start, end },
@@ -238,7 +243,10 @@ export class DatePeriodPicker extends PureComponent {
 							asDateRangePicker
 							selectedDateRange={selectedDateRange}
 							setSelectedDate={dateRange =>
-								setSelectedDate(dateRange, this.getDatePeriodIndex(dateRange))
+								setSelectedDate(
+									dateRange,
+									disableInferredDatePeriodIndex ? null : this.getDatePeriodIndex(dateRange),
+								)
 							}
 							validate={validate}
 							dateFunctions={dateFunctions}

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -40,6 +40,7 @@ export class DatePeriodPicker extends PureComponent {
 		dateFunctions: dateFunctionProps,
 		/** Debounce value for date inputs. Defaults to 500ms */
 		debounce: PropTypes.number,
+		disableCalendar: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -180,7 +181,7 @@ export class DatePeriodPicker extends PureComponent {
 	};
 
 	render() {
-		const { setSelectedDate, validate, dateFunctions } = this.props;
+		const { setSelectedDate, validate, dateFunctions, disableCalendar } = this.props;
 		const {
 			inputValues: { start, end },
 			selectedDateRange,
@@ -218,17 +219,19 @@ export class DatePeriodPicker extends PureComponent {
 						/>
 					</Styled.Label>
 				</Styled.DateInputContainer>
-				<Styled.DatePickerContainer>
-					<DatePicker
-						asDateRangePicker
-						selectedDateRange={selectedDateRange}
-						setSelectedDate={dateRange =>
-							setSelectedDate(dateRange, this.getDatePeriodIndex(dateRange))
-						}
-						validate={validate}
-						dateFunctions={dateFunctions}
-					/>
-				</Styled.DatePickerContainer>
+				{disableCalendar ? null : (
+					<Styled.DatePickerContainer>
+						<DatePicker
+							asDateRangePicker
+							selectedDateRange={selectedDateRange}
+							setSelectedDate={dateRange =>
+								setSelectedDate(dateRange, this.getDatePeriodIndex(dateRange))
+							}
+							validate={validate}
+							dateFunctions={dateFunctions}
+						/>
+					</Styled.DatePickerContainer>
+				)}
 			</Styled.Container>
 		);
 	}


### PR DESCRIPTION
I based this on a commit pretty far back (like 60 commits or something) so that this could be tested locally in the catalog.

The main changes needed here for chms are
1. Ability to disable the calendar input (`DatePicker`). I just added the ability to toggle the other inputs as well just incase.
2. Ability to distinguish between when the user selects an enumerated date period (`last 7 days`, `this month`, etc...) and when they enter a custom date range. This is so that when saving these ranges to report records, we know whether to save the date range as an explicit range, or recalculate the range next time they open the report. For example, if they create a report for records with birthdays `this month`, they are likely wanting to see birthdays for the current month each time they open the report. If they select a specific range, they probably don't want the range to change the next time they open the report.