### PR TITLE
Add v6 upgrade notes for Button and Select

### DIFF
--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -7,8 +7,24 @@
 - `Accordion`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for `Accordion.Panel` directly on that component.
 - `Button`
-  - Check your variants: `primaryOutline` has been replaced by `secondary`, and the inline version of `primaryTransparent` has been replaced by the new `link` variant.
-  - Check your sizes: standalone props have been replaced by the `size` prop, such as `size="medium"` instead of `medium`.
+  - Check your variants:
+    - `primaryOutline` has been replaced by `secondary`.
+    - `primaryTransparent` has been replaced by `link` and now uses inline spacing (no padding) by default.
+  - Check your sizes:
+    - Standalone props have been replaced by the `size` prop, such as `size="medium"` instead of `medium`.
+    - Size definitions have also changed, and the `condensed` prop is no longer used. The following table summarizes the differences:
+      ```
+                 ┌───────────────────────────┬────────────────────────────┬────────────────────────────┐
+                 │          "small"          │          "medium"          │          "large"           │
+                 ├─────┬──────────────┬──────┼──────┬──────────────┬──────┼──────┬──────────────┬──────┤
+                 │ v5  │ v5 condensed │  v6  │  v5  │ v5 condensed │  v6  │  v5  │ v5 condensed │  v6  │
+      ┌──────────┼─────┴──────────────┼──────┼──────┴──────────────┼──────┼──────┴──────────────┼──────┤
+      │ height   │        32px        │ 32px │        40px         │ 40px │        56px         │ 48px │
+      ├──────────┼─────┬──────────────┼──────┼──────┬──────────────┼──────┼──────┬──────────────┼──────┤
+      │ paddingX │ 8px │      6px     │  6px │ 14px │     10px     │ 10px │ 22px │     14px     │ 11px │
+      └──────────┴─────┴──────────────┴──────┴──────┴──────────────┴──────┴──────┴──────────────┴──────┘
+      ```
+    - Size variant styles no longer change the dimensions of child `<svg>`s, so manually resize yours as needed.
 - `Checkbox`
   - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `DatePickerInput`
@@ -53,3 +69,4 @@
     } from '@faithlife/styled-ui/text-input';
     ```
   - Deprecated components previously imported from `'@faithlife/styled-ui/dist/text-input'` (`Typeahead`, `AsyncTypeahead`, `Token`, `Menu`, `MenuItem`, `InferredTypeahead`) have been removed.
+  - `Select` components behave slightly differently now in one situation. When `isMulti` is `true`, if one or more options are selected and then later all selected options are removed, upon the removal of the last option the value passed to `onChange` will be `null`. In v5, the value passed to `onChange` in this situation would have been `[]`. See the [React Select v3 upgrade guide](https://github.com/JedWatson/react-select/issues/3585) for more details.


### PR DESCRIPTION
A few extra breaking changes I found in the process of [FaithlifeEquipment#255](https://git.faithlife.dev/Logos/FaithlifeEquipment/pull/255).

Is the new Unicode table a bit overkill? I found that Catalog could handle neither [GFM tables](https://github.github.com/gfm/#tables-extension-) nor HTML tables, so this was the best I could do. If it's too weird I could just summarize in some additional multilevel bullet points.