### PR TITLE
fix: Avatar stretching non square images incorrectly.

### DIFF
--- a/components/text-input/styled.jsx
+++ b/components/text-input/styled.jsx
@@ -13,6 +13,8 @@ export const AvatarOptionImage = styled.img`
 	border-radius: 10%;
 	height: 40px;
 	width: 40px;
+	max-width: 40px;
+	object-fit: cover;
 `;
 
 export const AvatarOptionCheckbox = styled.div`
@@ -44,6 +46,8 @@ export const AvatarMultiValueImage = styled.img`
 	border-radius: 10%;
 	height: 18px;
 	width: 18px;
+	max-width: 18px;
+	object-fit: cover;
 `;
 
 export const AvatarMultiValueName = styled.span`


### PR DESCRIPTION
We had a bug report that avatars were stretching incorrectly. This fixes the way it stretched to match the design.