### PR TITLE
Add a few more notes to the Upgrade Guide

### DIFF
--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -46,6 +46,8 @@
 - `ParameterSentence`
   - Subcomponents have been renamed: `ParameterSelect` to `ParameterSentence.Select`, `ParameterInputBox` to `ParameterSentence.Input`.
   - The `styleOverrides` prop has been removed in favor of Styled System props.
+- `Popover`
+  - The `styleOverrides` prop has been removed in favor of Styled System props.
 - `Radio`
   - The old `theme` prop functionality has been replaced by the [global theme object](https://faithlife.github.io/styled-ui/#/theme/usage) and Styled System props. Use the [`ThemeProvider` component](https://faithlife.github.io/styled-ui/#/theme/customization) to customize the theme.
 - `SimpleToast`
@@ -72,3 +74,5 @@
     ```
   - Deprecated components previously imported from `'@faithlife/styled-ui/dist/text-input'` (`Typeahead`, `AsyncTypeahead`, `Token`, `Menu`, `MenuItem`, `InferredTypeahead`) have been removed.
   - `Select` components behave slightly differently now in one situation. When `isMulti` is `true`, if one or more options are selected and then later all selected options are removed, upon the removal of the last option the value passed to `onChange` will be `null`. In v5, the value passed to `onChange` in this situation would have been `[]`. See the [React Select v3 upgrade guide](https://github.com/JedWatson/react-select/issues/3585) for more details.
+- `Tooltip`
+  - The `styleOverrides` prop has been removed in favor of Styled System props.

--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -4,6 +4,8 @@
 
 - Installation
   - Styled-UI v6 should be installed as a **direct** dependency, not a peerDependency anymore.
+- Importing
+  - Importing from `'@faithlife/styled-iu/v6'` has been deprecated—you can import v6 components from `'@faithlife/styled-ui'` now.
 - `Accordion`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for `Accordion.Panel` directly on that component.
 - `Button`

--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -5,7 +5,7 @@
 - Installation
   - Styled-UI v6 should be installed as a **direct** dependency, not a peerDependency anymore.
 - Importing
-  - Importing from `'@faithlife/styled-iu/v6'` has been deprecated—you can import v6 components from `'@faithlife/styled-ui'` now.
+  - Importing from `'@faithlife/styled-iu/v6'` has been removed—import v6 components from `'@faithlife/styled-ui'` now.
 - `Accordion`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for `Accordion.Panel` directly on that component.
 - `Button`

--- a/UpgradeGuide.md
+++ b/UpgradeGuide.md
@@ -5,7 +5,7 @@
 - Installation
   - Styled-UI v6 should be installed as a **direct** dependency, not a peerDependency anymore.
 - Importing
-  - Importing from `'@faithlife/styled-iu/v6'` has been removed—import v6 components from `'@faithlife/styled-ui'` now.
+  - Importing from `'@faithlife/styled-ui/v6'` has been removed—import v6 components from `'@faithlife/styled-ui'` now.
 - `Accordion`
   - The `styleOverrides` prop has been removed in favor of Styled System props. Use style props for `Accordion.Panel` directly on that component.
 - `Button`


### PR DESCRIPTION
Clearing up the `/v6` import confusion and also adding a breaking change in `Popover` and `Tooltip` I found during [FaithlifeEquipment#265](https://git.faithlife.dev/Logos/FaithlifeEquipment/pull/265).