### PR TITLE
Remove notice of continued /v6 entrypoint support from v5 docs

### DIFF
--- a/catalog/accordion/documentation-v6.md
+++ b/catalog/accordion/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Accordion component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API by importing `{ Accordion } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API by importing `{ Accordion } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from JSDoc comments.
 

--- a/catalog/accordion/variations-v6.md
+++ b/catalog/accordion/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Accordion component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API by importing `{ Accordion } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API by importing `{ Accordion } from '@faithlife/styled-ui/v6'`.
 
 These `<Accordion>` components follow the [WAI-ARIA spec for accordions](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
 

--- a/catalog/checkbox/documentation-v6.md
+++ b/catalog/checkbox/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Checkbox component has been rebuilt to use our global Styled System theme and two new config components instead of its legacy `theme` prop.
 
-You can opt in to the new API now by importing `{ Checkbox } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ Checkbox } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from jsdoc comments.
 

--- a/catalog/checkbox/variations-v6.md
+++ b/catalog/checkbox/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Checkbox component has been rebuilt to use our global Styled System theme and two new config components instead of its legacy `theme` prop.
 
-You can opt in to the new API now by importing `{ Checkbox } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ Checkbox } from '@faithlife/styled-ui/v6'`.
 
 ### Default theme
 

--- a/catalog/date-picker-input/documentation-v6.md
+++ b/catalog/date-picker-input/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the DatePickerInput component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API now by importing `{ DatePickerInput } from '@faithlife/styled-up/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ DatePickerInput } from '@faithlife/styled-up/v6'`.
 
 This documentation is automatically generated from JSDoc comments.
 

--- a/catalog/date-picker-input/variations-v6.md
+++ b/catalog/date-picker-input/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the DatePickerInput component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API now by importing `{ DatePickerInput } from '@faithlife/styled-up/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ DatePickerInput } from '@faithlife/styled-up/v6'`.
 
 ## Default Date Picker
 

--- a/catalog/help-box/documentation-v6.md
+++ b/catalog/help-box/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the HelpBox component has been rebuilt to use Styled System's theme and variant APIs.
 
-You can opt in to the new API now by importing `{ HelpBox } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ HelpBox } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from jsdoc comments.
 

--- a/catalog/help-box/variations-v6.md
+++ b/catalog/help-box/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the HelpBox component has been rebuilt to use Styled System's theme and variant APIs.
 
-You can opt in to the new API now by importing `{ HelpBox } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ HelpBox } from '@faithlife/styled-ui/v6'`.
 
 ## Colors and Their Meaning
 

--- a/catalog/loading-spinner/documentation-v6.md
+++ b/catalog/loading-spinner/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the LoadingSpinner component has been rebuilt to use Styled System primitives and its theme API.
 
-You can opt in to the new API now by importing `{ LoadingSpinner } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ LoadingSpinner } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from jsdoc comments.
 

--- a/catalog/loading-spinner/variations-v6.md
+++ b/catalog/loading-spinner/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the LoadingSpinner component has been rebuilt to use Styled System primitives and its theme API.
 
-You can opt in to the new API now by importing `{ LoadingSpinner } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ LoadingSpinner } from '@faithlife/styled-ui/v6'`.
 
 ### Default size
 

--- a/catalog/modal/documentation-v6.md
+++ b/catalog/modal/documentation-v6.md
@@ -2,8 +2,6 @@ For the next major version of Styled-UI, the Modal component has been rebuilt to
 
 You can opt-in to the new API now by importing `{ Modal } from @faithlife/styled-ui/v6`
 
-When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
-
 ```react
 noSource: true
 ---

--- a/catalog/modal/variations-v6.md
+++ b/catalog/modal/variations-v6.md
@@ -2,8 +2,6 @@ For the next major version of Styled-UI, the Modal component has been rebuilt to
 
 You can opt-in to the new API now by importing `{ Modal } from @faithlife/styled-ui/v6`
 
-When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
-
 ## Possible polyfill requirements
 
 This component assumes the availability of the following APIs, which may require polyfills in your application:

--- a/catalog/radio/documentation-v6.md
+++ b/catalog/radio/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Radio component has been rebuilt to use our global Styled System theme and two new config components instead of its legacy `theme` prop.
 
-You can opt in to the new API now by importing `{ Radio } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ Radio } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from jsdoc comments.
 

--- a/catalog/radio/variations-v6.md
+++ b/catalog/radio/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Radio component has been rebuilt to use our global Styled System theme and two new config components instead of its legacy `theme` prop.
 
-You can opt in to the new API now by importing `{ Radio } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ Radio } from '@faithlife/styled-ui/v6'`.
 
 ### Default theme
 

--- a/catalog/simple-toast/documentation-v6.md
+++ b/catalog/simple-toast/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the SimpleToast component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API now by importing `{ SimpleToast } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ SimpleToast } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from JSDoc comments.
 

--- a/catalog/simple-toast/variations-v6.md
+++ b/catalog/simple-toast/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the SimpleToast component has been rebuilt to use Styled System primitives.
 
-You can opt in to the new API now by importing `{ SimpleToast } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt in to the new API now by importing `{ SimpleToast } from '@faithlife/styled-ui/v6'`.
 
 ## v6 Simple Toast
 

--- a/catalog/slider/documentation-v6.md
+++ b/catalog/slider/documentation-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Slider component has been rebuilt to use Styled System primitives.
 
-You can opt-in to the new API now by importing `{ Slider } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt-in to the new API now by importing `{ Slider } from '@faithlife/styled-ui/v6'`.
 
 This documentation is automatically generated from JSDoc comments.
 

--- a/catalog/slider/variations-v6.md
+++ b/catalog/slider/variations-v6.md
@@ -1,6 +1,6 @@
 For the next major version of Styled UI, the Slider component has been rebuilt to use Styled System primitives.
 
-You can opt-in to the new API now by importing `{ Slider } from '@faithlife/styled-ui/v6'`. When v6 is released, the `/v6` entrypoint will continue to be supported with a deprecation warning until v7 is released.
+You can opt-in to the new API now by importing `{ Slider } from '@faithlife/styled-ui/v6'`.
 
 ## Slider
 


### PR DESCRIPTION
Following up on [this point](https://github.com/Faithlife/styled-ui/pull/446#discussion_r583771623) from #446.