### PR TITLE
Fix support for shift+home keys on Select components.

### DIFF
--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -227,7 +227,11 @@ function handleKeyDown(e, onConsumerKeyDown) {
 
 		if (selectionIndex !== null) {
 			if (e.shiftKey) {
-				e.target.selectionEnd = selectionIndex;
+				if (e.key === 'Home') {
+					e.target.selectionStart = selectionIndex;
+				} else {
+					e.target.selectionEnd = selectionIndex;
+				}
 			} else {
 				e.target.setSelectionRange(selectionIndex, selectionIndex);
 			}


### PR DESCRIPTION
Shift+Home should select all text from the cursor to the beginning of the input.
Shift+End should select all text from the cursor to the end of the input.