### PR TITLE
Fix Accordion.Panel padding bug (master)

### DIFF
--- a/components/accordion/accordion-panel.jsx
+++ b/components/accordion/accordion-panel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { variant } from 'styled-system';
+import { variant, padding } from 'styled-system';
 import { Collapse } from '../collapse';
 import { Box } from '../Box';
 import { useAccordionItemContext } from './accordion-util';
@@ -51,4 +51,5 @@ export const Panel = styled(Box).attrs(({ headerId, panelId }) => ({
 			},
 		},
 	}),
+	padding,
 );


### PR DESCRIPTION
Copy of #452 for `master`.

> Quick two-line bug fix for something that's blocking me on [FLCOM-6689](https://faithlife.atlassian.net/browse/FLCOM-6689).
>
> styled-components [applies styles inside-out](https://styled-components.com/docs/basics#extending-styles), so that when you wrap another styled-component in the `styled()` constructor, you can override the styles of the component you're wrapping. Because of this, defining the `variant` prop in `Panel` and relying on the wrapped `Box` to handle other Styled System props has made it impossible to override the padding set by `Accordion.Panel`'s default `variant="default"`. Setting, for example, `padding="0"` on `Accordion.Panel` does send that style to the underlying `Box`, but `Panel`'s styles win out because its CSS class is applied later.
>
> To fix this, I simply added Styled System's [`padding` style function](https://styled-system.com/packages#styled-system-packages) to `Panel` *after* the variants are defined. Now, using padding props on `Accordion.Panel` correctly overrides padding from the `variant` prop.