### PR TITLE
Focus number input on step button click (v6)

### DIFF
--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -16,6 +16,7 @@ const NumberInput = React.memo(
 
 		const dispatchChangeEvent = useCallback(() => {
 			inputRef.current.dispatchEvent(new Event('input', { bubbles: true }));
+			inputRef.current.focus();
 		}, []);
 
 		const handleStepUp = useCallback(() => {


### PR DESCRIPTION
A copy of #458 for `master`.

> Adds behavior to `NumberInput` that automatically focuses the input whenever its step buttons are clicked. Seems like an industry standard—[`<input type="number">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) does this on Chrome, Safari, and Edge. Plus, this way, value changes made with step buttons can be captured by an `onBlur` handler (which fixes a problem I'm running into on [Faithlife#4663](https://git.faithlife.dev/Logos/Faithlife/pull/4663)).
>
> The only problem is that the input still loses focus momentarily *during* a step button click (from `mousedown` to `mouseup`), but I can't think of a way to avoid that.
>
> ### Before:
>
> ![before](https://user-images.githubusercontent.com/5317080/112071748-144cbb80-8b36-11eb-8ed2-c90528b099e1.gif)
>
> ### After:
>
> ![after](https://user-images.githubusercontent.com/5317080/112071767-1d3d8d00-8b36-11eb-8615-fe50535a8b57.gif)