### PR TITLE
Convert WellButton to div

### DIFF
--- a/components/image-well/image-well-base.jsx
+++ b/components/image-well/image-well-base.jsx
@@ -14,7 +14,7 @@ export const WellContainer = styled(Box)`
 	${layout}
 `;
 
-export const WellButton = styled.button`
+export const WellButton = styled.div`
 	margin: 0;
 	padding: 0;
 	width: 100%;
@@ -24,10 +24,12 @@ export const WellButton = styled.button`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
+	text-align: center;
 	outline: none;
 	cursor: pointer;
 
 	border: none;
+	background-color: ${({ theme }) => theme.colors.button.minorBackground};
 	background-image: ${props => getBorderImage(props)};
 	border-radius: ${({ theme }) => theme.radii[2]};
 


### PR DESCRIPTION
Previously, the content tree for `ImageWell` looked like this:

```
ImageWell
-ImageWellBase
--WellButton
---styled.button        <-- Upper button
----WellPreview
-----RemoveIcon/CameraIcon
------RemoveIconContainer/CameraIconContainer
-------IconContainerBase
--------styled.UtilityButton
---------styled.Button  <-- Lower button
```

HTML does not allow buttons inside buttons, per the [specification](https://www.w3.org/TR/html52/sec-forms.html#the-button-element):

> **Content model**:
> Phrasing content, but there must be no [interactive content](https://www.w3.org/TR/html52/dom.html#interactive-content-2) descendant.

Most browsers will tolerate it, but React will loudly complain about it in dev mode and we should probably not try our luck with bad HTML.

An easy fix was to change the upper `styled.button` to a `styled.div`. There was no functional difference in doing so, but it lost a couple of the UA style rules for buttons, so I had to restore those.

In my testing of the catalog page, this code is identical to the previous code in every way *except* background color. The previous version was using the UA's default button color. In the case of Chrome, this was `rgb(239,239,239)`. Instead of using Chrome's button color, I used our theme's button background color, which is slightly different: `rgb(235,235,235)`.

Before:
![image](https://user-images.githubusercontent.com/4433153/114764632-0a733e00-9d19-11eb-87a9-712c638b424c.png)
After:
![image](https://user-images.githubusercontent.com/4433153/114764657-1101b580-9d19-11eb-884a-74a5dd8071c5.png)
