### PR TITLE
`NumberInput`: Send input value to `onStep` handler (v5)

### DIFF
--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -22,13 +22,13 @@ const NumberInput = React.memo(
 		const handleStepUp = useCallback(() => {
 			inputRef.current.stepUp();
 			dispatchChangeEvent();
-			onStep && onStep();
+			onStep && onStep(inputRef.current.value);
 		}, [dispatchChangeEvent, onStep]);
 
 		const handleStepDown = useCallback(() => {
 			inputRef.current.stepDown();
 			dispatchChangeEvent();
-			onStep && onStep();
+			onStep && onStep(inputRef.current.value);
 		}, [dispatchChangeEvent, onStep]);
 
 		const buttonPadding = variant === 'small' ? 2 : 3;
@@ -85,7 +85,7 @@ NumberInput.propTypes = {
 	alwaysShowButtons: PropTypes.bool,
 	/**
 	 * Runs when either step button is pressed.
-	 * @type {() => void}
+	 * @type {(inputValue: string) => void}
 	 */
 	onStep: PropTypes.func,
 };


### PR DESCRIPTION
Missed something I needed in #472 because I didn't test it locally with [Faithlife#4663](https://git.faithlife.dev/Logos/Faithlife/pull/4663). Now I have tested locally, and this fixes my issue.