### PR TITLE
Rename "carrot" to "caret" in `Menu.Toggle`

### DIFF
--- a/components/menu/menu-toggle.jsx
+++ b/components/menu/menu-toggle.jsx
@@ -1,11 +1,21 @@
 import React, { useMemo } from 'react';
-import { getConfigChild } from '../utils';
+import { deprecateProp, getConfigChild } from '../utils';
 import { Button, MultiButton } from '../button';
 import { Box } from '../Box';
 import { useDropdownContext, useKeyboardActivate } from './utils';
 import * as Styled from './styled';
 
-export function MenuToggle({ hideCarrot, size, variant, disabled, children, ...buttonProps }) {
+export function MenuToggle({
+	hideCaret,
+	hideCarrot,
+	size,
+	variant,
+	disabled,
+	children,
+	...buttonProps
+}) {
+	deprecateProp(hideCarrot, "The 'hideCarrot' prop has been deprecated in favor of 'hideCaret'.");
+
 	const { onToggleMenu, menuId, isOpen, toggleRef, onKeyboardNav } = useDropdownContext();
 
 	const onKeyPress = useKeyboardActivate(onToggleMenu, onKeyboardNav);
@@ -48,7 +58,7 @@ export function MenuToggle({ hideCarrot, size, variant, disabled, children, ...b
 				{...childProps.ariaProps}
 				{...buttonProps}
 			>
-				<Styled.DropdownCarrot hideMargin />
+				<Styled.DropdownCaret hideMargin />
 			</MultiButton>
 		</Box>
 	) : (
@@ -62,7 +72,7 @@ export function MenuToggle({ hideCarrot, size, variant, disabled, children, ...b
 			{...buttonProps}
 		>
 			{children}
-			{!hideCarrot && <Styled.DropdownCarrot />}
+			{!(hideCaret || hideCarrot) && <Styled.DropdownCaret />}
 		</Button>
 	);
 }

--- a/components/menu/styled.jsx
+++ b/components/menu/styled.jsx
@@ -7,17 +7,17 @@ import { Box } from '../Box';
 
 export const defaultMenuWidth = '160px';
 
-const DropdownCarrotComponent = styled(ChevronDown).attrs({ color: 'currentColor' })``;
+const DropdownCaretComponent = styled(ChevronDown).attrs({ color: 'currentColor' })``;
 
-const CarrotContainer = styled(Box).attrs(({ hideMargin }) => ({
+const CaretContainer = styled(Box).attrs(({ hideMargin }) => ({
 	marginLeft: !hideMargin ? 3 : 0,
 	color: 'inherit',
 }))``;
 
-export const DropdownCarrot = ({ hideMargin }) => (
-	<CarrotContainer hideMargin={hideMargin}>
-		<DropdownCarrotComponent />
-	</CarrotContainer>
+export const DropdownCaret = ({ hideMargin }) => (
+	<CaretContainer hideMargin={hideMargin}>
+		<DropdownCaretComponent />
+	</CaretContainer>
 );
 
 export const MenuItem = styled(UtilityButton)`


### PR DESCRIPTION
### [FLCOM-7075](https://faithlife.atlassian.net/browse/FLCOM-7075)

Just a minor spelling error that bugged me while I was working in this space. `Menu.Toggle`'s `hideCarrot` prop may confuse some people, though, so I've deprecated it in favor of a new `hideCaret` prop. But it won't break anything because it'll only give a console warning for `hideCarrot`.