### PR TITLE
Send style props to `Menu.Toggle` container when appropriate

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { variant, layout, flexbox, position, textStyle, border, background } from 'styled-system';
+import styledSystemPropTypes from '@styled-system/prop-types';
 import 'focus-visible';
 import { Box } from '../Box';
 import { common, typography } from '../../theme/system';
@@ -79,7 +81,31 @@ const ButtonCore = styled.button.attrs(({ active }) => ({ className: active ? 'a
 	${border}
 	${background}
 `;
-
+ButtonCore.propTypes = {
+	...common.propTypes,
+	...typography.propTypes,
+	...styledSystemPropTypes.textStyle,
+	...styledSystemPropTypes.layout,
+	...styledSystemPropTypes.flexbox,
+	...styledSystemPropTypes.position,
+	...styledSystemPropTypes.border,
+	...styledSystemPropTypes.background,
+	size: PropTypes.oneOf(['small', 'medium', 'large']),
+	variant: PropTypes.oneOf([
+		'primary',
+		'secondary',
+		'minor',
+		'minorTransparent',
+		'link',
+		'danger',
+		'dangerSpecial',
+	]),
+	active: PropTypes.bool,
+	disabled: PropTypes.bool,
+	isLoading: PropTypes.bool,
+	theme: PropTypes.object,
+	children: PropTypes.node,
+};
 ButtonCore.defaultProps = {
 	theme,
 	size: 'medium',
@@ -112,6 +138,11 @@ export const Button = React.forwardRef(
 		</ButtonCore>
 	),
 );
+Button.propTypes = {
+	...ButtonCore.propTypes,
+	icon: PropTypes.node,
+	loading: PropTypes.bool,
+};
 
 export const MultiButton = styled(Button).attrs(({ variant, border, borderColor }) => ({
 	variant: variant ?? 'transparent',
@@ -141,7 +172,10 @@ export const MultiButton = styled(Button).attrs(({ variant, border, borderColor 
 		border-bottom-right-radius: 0;
 	}
 `;
-
+MultiButton.propTypes = {
+	...Button.propTypes,
+	selected: PropTypes.bool,
+};
 MultiButton.defaultProps = { theme };
 
 export const SegmentedButtonGroup = deprecateComponent(

--- a/components/menu/menu-toggle.jsx
+++ b/components/menu/menu-toggle.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styledSystemPropTypes from '@styled-system/prop-types';
-import { deprecateProp, getConfigChild } from '../utils';
+import { deprecateProp, filterProps, getConfigChild } from '../utils';
 import { Button, MultiButton } from '../button';
 import { Box } from '../Box';
 import { useDropdownContext, useKeyboardActivate } from './utils';
@@ -40,8 +40,19 @@ export function MenuToggle({
 	}
 
 	const [actionChild] = getConfigChild(children, MenuActionButton.childConfigComponent);
+	const { matchingProps: containerProps, remainingProps: caretButtonProps } = filterProps(
+		buttonProps,
+		{
+			...styledSystemPropTypes.space,
+			...styledSystemPropTypes.layout,
+			...styledSystemPropTypes.flexbox,
+			...styledSystemPropTypes.grid,
+			...styledSystemPropTypes.position,
+		},
+	);
+
 	return actionChild ? (
-		<Box>
+		<Box {...containerProps}>
 			{React.cloneElement(actionChild, {
 				defaultSize: size,
 				defaultVariant: variant,
@@ -58,7 +69,7 @@ export function MenuToggle({
 				borderColor="blue5"
 				{...childProps}
 				{...childProps.ariaProps}
-				{...buttonProps}
+				{...caretButtonProps}
 			>
 				<Styled.DropdownCaret hideMargin />
 			</MultiButton>

--- a/components/menu/menu-toggle.jsx
+++ b/components/menu/menu-toggle.jsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import styledSystemPropTypes from '@styled-system/prop-types';
 import { deprecateProp, getConfigChild } from '../utils';
 import { Button, MultiButton } from '../button';
 import { Box } from '../Box';
@@ -76,7 +78,12 @@ export function MenuToggle({
 		</Button>
 	);
 }
-
+MenuToggle.propTypes = {
+	...MultiButton.propTypes,
+	...styledSystemPropTypes.grid,
+	hideCaret: PropTypes.bool,
+	hideCarrot: PropTypes.bool,
+};
 MenuToggle.defaultProps = {
 	size: 'small',
 	variant: 'primary',

--- a/components/menu/menu-toggle.jsx
+++ b/components/menu/menu-toggle.jsx
@@ -52,7 +52,7 @@ export function MenuToggle({
 	);
 
 	return actionChild ? (
-		<Box {...containerProps}>
+		<Box display="inline-flex" {...containerProps}>
 			{React.cloneElement(actionChild, {
 				defaultSize: size,
 				defaultVariant: variant,
@@ -115,6 +115,7 @@ export function MenuActionButton({
 			size={defaultSize}
 			variant={defaultVariant}
 			disabled={defaultDisabled}
+			flexGrow={1}
 			{...buttonProps}
 		>
 			{children}


### PR DESCRIPTION
### [FLCOM-7017](https://faithlife.atlassian.net/browse/FLCOM-7017) part 1

When `Menu.ActionButton` is being used, a lot of `Menu.Toggle` props are currently being sent to the caret button that ought to be sent to the container. For example, one would expect `<Menu.Toggle width="100%">` to only affect the container's width, but right now that would just make the caret button on the right comically wide.

Adding prop types to several components in the first commit helped me determine which style props needed to be filtered.