### PR TITLE
Make `Select` components clearable by default

### DIFF
--- a/catalog/input/select.md
+++ b/catalog/input/select.md
@@ -1,14 +1,9 @@
-A typeahead control with keyboard navigation based on react-select.
+A typeahead control with keyboard navigation based on [React Select](https://react-select.com).
 
-[Component documentation](https://github.com/JedWatson/react-select)
+### Upgrading from v5 to v6
 
-### Migration guide from v5 to v6:
-
-- Change the import to `text-input` (see below)
-
-```
-import { Select } from '@faithlife/styled-ui/text-input';
-```
+1. Import from `'@faithlife/styled-ui/text-input'` instead of `'@faithlife/styled-ui/dist/text-input-v2'`.
+2. `onChange` behaves a bit differently now when `isMulti` is `true`. If one or more options are selected and then later all selected options are removed, upon the removal of the last option the value passed to `onChange` will be `null`. In v5, the value passed to `onChange` in this situation would have been `[]`. See the [React Select v3 upgrade guide](https://github.com/JedWatson/react-select/issues/3585) for more details.
 
 ### Single select
 

--- a/catalog/input/select.md
+++ b/catalog/input/select.md
@@ -19,9 +19,7 @@ state: { selection: '' }
 <div>
 	<div>Current selection: {state.selection}</div>
 	<Select
-		onChange={({ value }) => {
-			setState({ selection: value });
-		}}
+		onChange={selectedOption => setState({ selection: selectedOption ? selectedOption.value : '' })}
 		options={[
 			{ value: "washington", label: "Washington" },
 			{ value: "california", label: "California" },
@@ -41,9 +39,7 @@ state: { selection: '' }
 <div>
 	<div>Current selection: {state.selection}</div>
 	<Select
-		onChange={({ value }) => {
-			setState({ selection: value });
-		}}
+		onChange={selectedOption => setState({ selection: selectedOption ? selectedOption.value : '' })}
 		isSearchable={false}
 		options={[
 			{ value: "washington", label: "Washington" },
@@ -59,7 +55,7 @@ state: { selection: '' }
 
 ```react
 showSource: true
-state: { modal: false, value: '', selection: '' }
+state: { modal: false, selection: '' }
 ---
 <div>
 	<Button variant="primary" size="medium" onClick={() => setState({ modal: !state.modal })}>Open a modal!</Button>
@@ -75,9 +71,8 @@ state: { modal: false, value: '', selection: '' }
 		<DemoDiv>
 			<div>Current selection: {state.selection}</div>
 			<Select
-				onChange={({ value }) => {
-					setState({ selection: value });
-				}}
+				onChange={selectedOption =>
+					setState({ selection: selectedOption ? selectedOption.value : '' })}
 				options={[
 					{ value: "washington", label: "Washington" },
 					{ value: "california", label: "California" },
@@ -94,13 +89,13 @@ state: { modal: false, value: '', selection: '' }
 
 ```react
 showSource: true
-state: { tags: [] }
+state: { selection: [] }
 ---
 <div>
-	<div>Current selection: {state.selection}</div>
+	<div>Current selection: {state.selection.join(', ')}</div>
 	<Select
-		onChange={({ value }) => {
-			setState({ selection: value });
+		onChange={(selectedOptions) => {
+			setState({ selection: selectedOptions ? selectedOptions.map(option => option.value) : [] });
 		}}
 		isMulti
 		options={[
@@ -117,13 +112,13 @@ state: { tags: [] }
 
 ```react
 showSource: true
-state: { tags: [] }
+state: { selection: [] }
 ---
 <div>
-	<div>Current selection: {state.selection}</div>
+	<div>Current selection: {state.selection.join(', ')}</div>
 	<CreatableSelect
-		onChange={({ value }) => {
-			setState({ selection: value });
+		onChange={(selectedOptions) => {
+			setState({ selection: selectedOptions ? selectedOptions.map(option => option.value) : [] });
 		}}
 		isMulti
 		options={[
@@ -143,10 +138,10 @@ showSource: true
 state: { selection: [], pendingSelectedValues: [{value: 'Texas', label: 'Texas'}] }
 ---
 <div>
-	<div>Current selection: {state.selection}</div>
+	<div>Current selection: {state.selection.join(', ')}</div>
 	<CreatableSelect
-		onChange={({ value }) => {
-			setState({ selection: value });
+		onChange={(selectedOptions) => {
+			setState({ selection: selectedOptions ? selectedOptions.map(option => option.value) : [] });
 		}}
 		isMulti
 		options={[

--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -5,6 +5,7 @@ import { colors } from '../shared-styles';
 import { ChevronDown } from '../icons/12px';
 import { Checkbox } from '../../components/check-box';
 import { DebouncedSelectAsync, DebouncedSelectAsyncCreatable } from './debounced-async';
+import { useClearableSelectValue } from './use-clearable-select-value';
 import * as Styled from './styled';
 import { ThemedBox } from '../ThemedBox';
 import { useTheme } from '../../theme';
@@ -281,14 +282,36 @@ export function useCommonSelectProps(props, ref) {
 		components,
 		disabled,
 		isDisabled,
-		isClearable = true,
 		styles,
 		onKeyDown,
+		value,
+		defaultValue,
+		onChange,
+		inputValue,
+		defaultInputValue,
+		onInputChange,
+		isClearable = true,
+		isMulti,
 		...otherProps
 	} = props;
 
 	const body = useBody();
 	const theme = useTheme();
+	const {
+		innerValue,
+		innerOnChange,
+		innerInputValue,
+		innerOnInputChange,
+	} = useClearableSelectValue({
+		value,
+		defaultValue,
+		onChange,
+		inputValue,
+		defaultInputValue,
+		onInputChange,
+		isClearable,
+		isMulti,
+	});
 
 	return {
 		ref: ref,
@@ -298,9 +321,14 @@ export function useCommonSelectProps(props, ref) {
 		noOptionsMessage: noOptionsMessage,
 		menuPortalTarget: body,
 		isDisabled: disabled || isDisabled,
-		isClearable: isClearable,
 		styles: selectStyles(props, theme),
 		onKeyDown: e => handleKeyDown(e, onKeyDown),
+		value: innerValue,
+		onChange: innerOnChange,
+		inputValue: innerInputValue,
+		onInputChange: innerOnInputChange,
+		isClearable: isClearable,
+		isMulti: isMulti,
 		...otherProps,
 	};
 }

--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -242,111 +242,68 @@ function handleKeyDown(e, onConsumerKeyDown) {
 export { reactSelectComponents };
 
 /** Autocomplete control based on react-select */
-export const Select = React.forwardRef(
-	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
-		const body = useBody();
-		const onConsumerKeyDown = props.onKeyDown;
-
-		const theme = useTheme();
-
-		return (
-			<ReactSelect
-				ref={ref}
-				classNamePrefix="fl-select"
-				theme={selectTheme}
-				components={{ ...defaultComponents, ...components }}
-				noOptionsMessage={noOptionsMessage}
-				menuPortalTarget={body}
-				isDisabled={disabled || isDisabled}
-				isClearable={isClearable}
-				{...props}
-				styles={selectStyles(props, theme)}
-				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
-			/>
-		);
-	},
-);
+export const Select = React.forwardRef((props, ref) => {
+	const transformedProps = useCommonSelectProps(props, ref);
+	return <ReactSelect {...transformedProps} />;
+});
 
 /** The same as `Select`, but allows new entries. */
-export const CreatableSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
-		const body = useBody();
-		const onConsumerKeyDown = props.onKeyDown;
-
-		const theme = useTheme();
-
-		return (
-			<ReactSelectCreatable
-				ref={ref}
-				classNamePrefix="fl-select"
-				theme={selectTheme}
-				formatCreateLabel={node => <span>New entry: {node}</span>}
-				components={{ ...defaultComponents, ...components }}
-				noOptionsMessage={noOptionsMessage}
-				menuPortalTarget={body}
-				isDisabled={disabled || isDisabled}
-				isClearable={isClearable}
-				{...props}
-				styles={selectStyles(props, theme)}
-				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
-			/>
-		);
-	},
-);
+export const CreatableSelect = React.forwardRef((props, ref) => {
+	const transformedProps = useCommonSelectProps(props, ref);
+	return (
+		<ReactSelectCreatable
+			formatCreateLabel={node => <span>New entry: {node}</span>}
+			{...transformedProps}
+		/>
+	);
+});
 
 /** The same as `Select`, but allows new entries and fetches data asynchronously. */
-export const AsyncCreatableSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
-		const body = useBody();
-		const onConsumerKeyDown = props.onKeyDown;
-
-		const theme = useTheme();
-
-		return (
-			<DebouncedSelectAsyncCreatable
-				ref={ref}
-				allowCreateWhileLoading={false}
-				classNamePrefix="fl-select"
-				theme={selectTheme}
-				components={{ ...defaultComponents, ...components }}
-				formatCreateLabel={node => <span>New entry: {node}</span>}
-				noOptionsMessage={noOptionsMessage}
-				menuPortalTarget={body}
-				isDisabled={disabled || isDisabled}
-				isClearable={isClearable}
-				{...props}
-				styles={selectStyles(props, theme)}
-				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
-			/>
-		);
-	},
-);
+export const AsyncCreatableSelect = React.forwardRef((props, ref) => {
+	const transformedProps = useCommonSelectProps(props, ref);
+	return (
+		<DebouncedSelectAsyncCreatable
+			allowCreateWhileLoading={false}
+			formatCreateLabel={node => <span>New entry: {node}</span>}
+			{...transformedProps}
+		/>
+	);
+});
 
 /** The same as `Select`, but fetches options asynchronously. */
-export const AsyncSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
-		const body = useBody();
-		const onConsumerKeyDown = props.onKeyDown;
+export const AsyncSelect = React.forwardRef((props, ref) => {
+	const transformedProps = useCommonSelectProps(props, ref);
+	return <DebouncedSelectAsync {...transformedProps} />;
+});
 
-		const theme = useTheme();
+export function useCommonSelectProps(props, ref) {
+	const {
+		components,
+		disabled,
+		isDisabled,
+		isClearable = true,
+		styles,
+		onKeyDown,
+		...otherProps
+	} = props;
 
-		return (
-			<DebouncedSelectAsync
-				ref={ref}
-				classNamePrefix="fl-select"
-				theme={selectTheme}
-				components={{ ...defaultComponents, ...components }}
-				noOptionsMessage={noOptionsMessage}
-				menuPortalTarget={body}
-				isDisabled={disabled || isDisabled}
-				isClearable={isClearable}
-				{...props}
-				styles={selectStyles(props, theme)}
-				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
-			/>
-		);
-	},
-);
+	const body = useBody();
+	const theme = useTheme();
+
+	return {
+		ref: ref,
+		classNamePrefix: 'fl-select',
+		theme: selectTheme,
+		components: { ...defaultComponents, ...components },
+		noOptionsMessage: noOptionsMessage,
+		menuPortalTarget: body,
+		isDisabled: disabled || isDisabled,
+		isClearable: isClearable,
+		styles: selectStyles(props, theme),
+		onKeyDown: e => handleKeyDown(e, onKeyDown),
+		...otherProps,
+	};
+}
 
 function useBody() {
 	const [body, setBody] = useState(null);

--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactSelect, { components as reactSelectComponents } from 'react-select';
 import ReactSelectCreatable from 'react-select/creatable';
 import { colors } from '../shared-styles';
@@ -247,7 +247,6 @@ export const Select = React.forwardRef(
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
-		const onChange = useLegacyChangeHandler(props.onChange, props.isMulti);
 		const theme = useTheme();
 
 		return (
@@ -261,7 +260,6 @@ export const Select = React.forwardRef(
 				isDisabled={disabled || isDisabled}
 				isClearable={isClearable}
 				{...props}
-				onChange={onChange}
 				styles={selectStyles(props, theme)}
 				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 			/>
@@ -275,7 +273,6 @@ export const CreatableSelect = React.forwardRef(
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
-		const onChange = useLegacyChangeHandler(props.onChange, props.isMulti);
 		const theme = useTheme();
 
 		return (
@@ -290,7 +287,6 @@ export const CreatableSelect = React.forwardRef(
 				isDisabled={disabled || isDisabled}
 				isClearable={isClearable}
 				{...props}
-				onChange={onChange}
 				styles={selectStyles(props, theme)}
 				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 			/>
@@ -304,7 +300,6 @@ export const AsyncCreatableSelect = React.forwardRef(
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
-		const onChange = useLegacyChangeHandler(props.onChange, props.isMulti);
 		const theme = useTheme();
 
 		return (
@@ -320,7 +315,6 @@ export const AsyncCreatableSelect = React.forwardRef(
 				isDisabled={disabled || isDisabled}
 				isClearable={isClearable}
 				{...props}
-				onChange={onChange}
 				styles={selectStyles(props, theme)}
 				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 			/>
@@ -334,7 +328,6 @@ export const AsyncSelect = React.forwardRef(
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
-		const onChange = useLegacyChangeHandler(props.onChange, props.isMulti);
 		const theme = useTheme();
 
 		return (
@@ -348,7 +341,6 @@ export const AsyncSelect = React.forwardRef(
 				isDisabled={disabled || isDisabled}
 				isClearable={isClearable}
 				{...props}
-				onChange={onChange}
 				styles={selectStyles(props, theme)}
 				onKeyDown={e => handleKeyDown(e, onConsumerKeyDown)}
 			/>
@@ -363,17 +355,4 @@ function useBody() {
 	}, []);
 
 	return body;
-}
-
-// TODO: Remove in version 6.0
-// This undoes the change type normalization introduced in react-select 3
-function useLegacyChangeHandler(onChange, isMulti) {
-	return useCallback(
-		(values, change) => {
-			if (onChange) {
-				return onChange(isMulti ? values || [] : values, change);
-			}
-		},
-		[isMulti, onChange],
-	);
 }

--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -243,7 +243,7 @@ export { reactSelectComponents };
 
 /** Autocomplete control based on react-select */
 export const Select = React.forwardRef(
-	({ components = {}, disabled, isDisabled, ...props }, ref) => {
+	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
@@ -259,6 +259,7 @@ export const Select = React.forwardRef(
 				noOptionsMessage={noOptionsMessage}
 				menuPortalTarget={body}
 				isDisabled={disabled || isDisabled}
+				isClearable={isClearable}
 				{...props}
 				onChange={onChange}
 				styles={selectStyles(props, theme)}
@@ -270,7 +271,7 @@ export const Select = React.forwardRef(
 
 /** The same as `Select`, but allows new entries. */
 export const CreatableSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, ...props }, ref) => {
+	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
@@ -287,6 +288,7 @@ export const CreatableSelect = React.forwardRef(
 				noOptionsMessage={noOptionsMessage}
 				menuPortalTarget={body}
 				isDisabled={disabled || isDisabled}
+				isClearable={isClearable}
 				{...props}
 				onChange={onChange}
 				styles={selectStyles(props, theme)}
@@ -298,7 +300,7 @@ export const CreatableSelect = React.forwardRef(
 
 /** The same as `Select`, but allows new entries and fetches data asynchronously. */
 export const AsyncCreatableSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, ...props }, ref) => {
+	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
@@ -316,6 +318,7 @@ export const AsyncCreatableSelect = React.forwardRef(
 				noOptionsMessage={noOptionsMessage}
 				menuPortalTarget={body}
 				isDisabled={disabled || isDisabled}
+				isClearable={isClearable}
 				{...props}
 				onChange={onChange}
 				styles={selectStyles(props, theme)}
@@ -327,7 +330,7 @@ export const AsyncCreatableSelect = React.forwardRef(
 
 /** The same as `Select`, but fetches options asynchronously. */
 export const AsyncSelect = React.forwardRef(
-	({ components = {}, disabled, isDisabled, ...props }, ref) => {
+	({ components = {}, disabled, isDisabled, isClearable = true, ...props }, ref) => {
 		const body = useBody();
 		const onConsumerKeyDown = props.onKeyDown;
 
@@ -343,6 +346,7 @@ export const AsyncSelect = React.forwardRef(
 				noOptionsMessage={noOptionsMessage}
 				menuPortalTarget={body}
 				isDisabled={disabled || isDisabled}
+				isClearable={isClearable}
 				{...props}
 				onChange={onChange}
 				styles={selectStyles(props, theme)}

--- a/components/text-input/use-clearable-select-value.js
+++ b/components/text-input/use-clearable-select-value.js
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+import { useOptionallyControlledState } from '../utils/use-optionally-controlled-state';
+
+/**
+ * A React Select workaround to clear the `Select` value when the user is typing into the `Select`'s
+ * input (as long as the `Select` is only for a single value and is clearable).
+ */
+export function useClearableSelectValue({
+	value: controlledSelectValue,
+	defaultValue: defaultSelectValue,
+	onChange: onSelectChange,
+	inputValue: controlledInputValue,
+	defaultInputValue,
+	onInputChange,
+	isClearable,
+	isMulti,
+}) {
+	const [selectValue, trySetSelectValue] = useOptionallyControlledState(
+		controlledSelectValue,
+		defaultSelectValue,
+	);
+	const [inputValue, trySetInputValue] = useOptionallyControlledState(
+		controlledInputValue,
+		defaultInputValue,
+	);
+
+	const innerOnSelectChange = useCallback(
+		(newSelectValue, meta) => {
+			trySetSelectValue(newSelectValue);
+			if (onSelectChange) {
+				onSelectChange(newSelectValue, meta);
+			}
+		},
+		[onSelectChange, trySetSelectValue],
+	);
+	const innerOnInputChange = useCallback(
+		(newInputValue, meta) => {
+			const userIsTyping = meta.action === 'input-change';
+			if (isClearable && !isMulti && userIsTyping) {
+				innerOnSelectChange(null, { action: 'set-value' });
+			}
+
+			trySetInputValue(newInputValue);
+			if (onInputChange) {
+				onInputChange(newInputValue, meta);
+			}
+		},
+		[innerOnSelectChange, isClearable, isMulti, onInputChange, trySetInputValue],
+	);
+
+	return {
+		innerValue: selectValue,
+		innerOnChange: innerOnSelectChange,
+		innerInputValue: inputValue,
+		innerOnInputChange,
+	};
+}

--- a/components/utils/use-optionally-controlled-state.js
+++ b/components/utils/use-optionally-controlled-state.js
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+const EMPTY_FUNCTION = () => {};
+
+/**
+ * For situations when a value can be controlled externally via props, but if it isn't controlled
+ * you'd like to control it internally via state.
+ * @param {any} controlledValue - The prop that can externally control the value when defined.
+ * @param {any} defaultValue - An optional default value to initialize the state with when the value
+ * is not externally controlled.
+ * @returns {[value: any, trySetValue: (newValue?: any) => void]} An array of the state value and
+ * either a setter function or (if the value is externally controlled) an empty function.
+ */
+export function useOptionallyControlledState(controlledValue, defaultValue) {
+	const [value, setValue] = useState(defaultValue);
+
+	if (controlledValue !== undefined) {
+		return [controlledValue, EMPTY_FUNCTION];
+	} else {
+		return [value, setValue];
+	}
+}


### PR DESCRIPTION
### [FLCOM-6739](https://faithlife.atlassian.net/browse/FLCOM-6739)

It was noted as confusing that clearing a `Select` component leaves an old value in the input. After investigating the [React Select docs](https://react-select.com), I'm guessing that such components weren't clearable at all, since [its `Select` components have](https://react-select.com/props#select-props) an `isClearable` prop that is falsy by default.

This PR adds an explicit `isClearable` prop to all Styled UI `Select` components and gives it a default value of `true`.

Probably the easiest way to test this would be to ~check out the branch, then `yarn && yarn build && yarn catalog-start`, then go to http://localhost:4000/#/text-input/select~ _go to https://deploy-preview-478--faithlife-styled-ui.netlify.app/#/text-input/select_.