### PR TITLE
Set `Button` hover text colors explicitly

### DIFF
--- a/theme/buttons.js
+++ b/theme/buttons.js
@@ -28,6 +28,7 @@ export const buttons = {
 		border: 1,
 		borderColor: 'button.primaryBackground',
 		'&:hover': {
+			color: 'button.primaryForeground',
 			backgroundColor: 'button.primaryHover',
 			borderColor: 'button.primaryHover',
 		},
@@ -67,6 +68,7 @@ export const buttons = {
 		backgroundColor: 'button.minorBackground',
 		borderColor: 'button.minorBackground',
 		'&:hover': {
+			color: 'button.minorForeground',
 			backgroundColor: 'button.minorHover',
 			borderColor: 'button.minorHover',
 		},
@@ -86,6 +88,7 @@ export const buttons = {
 		backgroundColor: 'transparent',
 		borderColor: 'transparent',
 		'&:hover': {
+			color: 'button.minorForeground',
 			backgroundColor: 'button.transparentHover',
 			borderColor: 'button.transparentHover',
 		},
@@ -158,6 +161,7 @@ export const buttons = {
 		backgroundColor: 'button.dangerBackground',
 		borderColor: 'button.dangerBackground',
 		'&:hover': {
+			color: 'button.dangerForeground',
 			backgroundColor: 'button.dangerHover',
 			borderColor: 'button.dangerHover',
 		},


### PR DESCRIPTION
### [FLCOM-6930](https://faithlife.atlassian.net/browse/FLCOM-6930)

Fixes a conflict with FLCOM global styles when using `<Button as="a" />`, as the resulting buttons (in these four variants) get the default hover text color for `<a>`s when hovered instead of the desired button text colors. Example:

![Link Button hover bug](https://user-images.githubusercontent.com/5317080/117226167-e9a68180-adc8-11eb-9d69-1679fc463ca8.gif)

To test indirectly 😬:

1. Go to https://internal.faithlife.com/example-community-church/communications#/.
2. Hover over the "Add communication" button and note the bug.
3. Right-click the button and hit "Inspect".
4. Force a hover state and add `color: #ffffff` to the `Button` hover styles, noting how that fixes the bug.
   <img width="894" alt="Hover color fix" src="https://user-images.githubusercontent.com/5317080/117226968-aa793000-adca-11eb-90f8-c61c8b2324e1.png">
5. If you're feeling ambitious, run FLCOM locally, go to http://localhost:8080/example-community-church/communications#/, find the affected `Button` in React Dev Tools, and change the `variant` prop to each of the affected variants, repeating steps 2–4 for each.