### PR TITLE
Revert new default value of `Select`'s `isClearable` prop

### DIFF
--- a/components/text-input/select.jsx
+++ b/components/text-input/select.jsx
@@ -290,7 +290,7 @@ export function useCommonSelectProps(props, ref) {
 		inputValue,
 		defaultInputValue,
 		onInputChange,
-		isClearable = true,
+		isClearable,
 		isMulti,
 		...otherProps
 	} = props;


### PR DESCRIPTION
Suddenly defaulting `isClearable` to `true` broke several `Select`s in ChMS (and likely elsewhere), since they'd (naturally) written `onChange` handlers had never needed to expect null values before. This PR just removes that default value—none of the other changes from #478 should be breaking.

See [this thread](https://beta.faithlife.com/messages/flcom-team?threadId=1428524) for more background/discussion.