### PR TITLE
Fix build package before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"test": "npm run test:ci && npm run eslint && npm run stylelint",
 		"precommit": "prettier --write \"./components/**/*.{js,jsx}\" && npm run stylelint",
 		"build": "rimraf dist && webpack --mode=none",
-		"prepublishOnly": "npm test",
+		"prepublishOnly": "npm run build && npm test",
 		"postpublish": "yarn helmsman ship-to @faithlife/styled-ui@5.75.1 latest --no-ship-faithlife",
 		"stylelint": "stylelint ./components/**/*.jsx",
 		"test:jest": "jest --maxWorkers=50%",


### PR DESCRIPTION
The jenkins job and the package.json to publish `styled-ui` was missing the `npm run build` command; which resulted in the published package missing the `dist` directory.  Added it to the `prepublishOnly` step so that the package would be built properly before packing it for publishing.