### PR TITLE
Disallow console.log statements.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
 	"extends": ["faithlife"],
 	"rules": {
 		"react/jsx-no-literals": "off",
-		"react/display-name": "off"
+		"react/display-name": "off",
+		"no-console": ["error", {"allow": ["error", "warn"]}]
 	},
 	"env": {
 		"jest": true


### PR DESCRIPTION
No `console.log` statements presently exist. I don't think any have been added intentionally and cannot think of valid use cases for them.

I was motivated to add this when I realized https://git.faithlife.dev/Logos/Tasks presently uses a version of styled-ui that does not have this `console.log` removed: https://github.com/Faithlife/styled-ui/commit/b01e3a64689f3f6f741f7c32a4abce2655551210#diff-5ab49f2fb4093eae8a036eab605ec20cc867ac71c545d6c6148ef306a9f0936bL12