### PR TITLE
🐛 Addresses an issue in macOS Safari where stepUp/stepDown on an input would crash

### DIFF
--- a/components/input/NumberInput.jsx
+++ b/components/input/NumberInput.jsx
@@ -20,12 +20,18 @@ const NumberInput = React.memo(
 		}, []);
 
 		const handleStepUp = useCallback(() => {
+			if (!inputRef.current.value) {
+				inputRef.current.value = 0;
+			}
 			inputRef.current.stepUp();
 			dispatchChangeEvent();
 			onStep && onStep(inputRef.current.value);
 		}, [dispatchChangeEvent, onStep]);
 
 		const handleStepDown = useCallback(() => {
+			if (!inputRef.current.value) {
+				inputRef.current.value = 0;
+			}
 			inputRef.current.stepDown();
 			dispatchChangeEvent();
 			onStep && onStep(inputRef.current.value);


### PR DESCRIPTION
Addresses an issue in Safari lts affecting NumberInput where stepUp/stepDown on an input would crash

[Example (affects macOS 14.0.3 (at least) - lts)](https://codesandbox.io/s/great-mccarthy-s2ybz
)
Treat empty input values as 0 when handling stepUp/stepDown