### PR TITLE
Add DatePicker Footer support

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.9.0
+
+- Added `DatePicker.Footer` to the `DatePicker` module.
+
 ## 6.8.1
 
 - Fix PropTypes for `Modal`.

--- a/catalog/date-picker-input/variations.md
+++ b/catalog/date-picker-input/variations.md
@@ -8,14 +8,14 @@ noSource: true
 </React.Fragment>
 ```
 
-## Default Date Picker
+## Default Date Picker Input
 
 ```react
 showSource: true
 state: { selectedDate: null }
 ---
 <div>
-	<span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
+	<span>The selected date is {state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
 	<DatePickerInput
 		defaultSelectedDate={state.selectedDate || new Date()}
 		onChange={(date) => setState({ selectedDate: date })}
@@ -26,14 +26,14 @@ state: { selectedDate: null }
 </div>
 ```
 
-## Customized placement of Date Picker
+## Customized placement of Date Picker Input
 
 ```react
 showSource: true
 state: { selectedDate: null }
 ---
 <div>
-	<span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
+	<span>The selected date is {state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
 	<DatePickerInput
 		defaultSelectedDate={state.selectedDate || new Date()}
 		onChange={(date) => setState({ selectedDate: date })}
@@ -45,17 +45,18 @@ state: { selectedDate: null }
 </div>
 ```
 
-## Custom props on Date Picker
+## Custom props on Date Picker Input
 
 Extra props on the DatePicker Input will be passed to the Input. Useful for adding IDs to assign labels.
 Additional config components can be used to pass props to the button and popover.
+Children are also passed through to `DatePicker` to allow further customizations.
 
 ```react
 showSource: true
 state: { selectedDate: null }
 ---
 <div>
-	<label htmlFor="date-picker-input">The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</label>
+	<label htmlFor="date-picker-input">The selected date is {state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</label>
 	<DatePickerInput
 		id="date-picker-input"
 		defaultSelectedDate={state.selectedDate || new Date()}
@@ -66,6 +67,15 @@ state: { selectedDate: null }
 	>
 		<DatePickerInput.Button color="green4" />
 		<DatePickerInput.Popover container="body" placement="left-start" />
+		<DatePicker.Footer display="flex" justifyContent="end">
+			<Button
+				variant="secondary"
+				height="22px"
+				onClick={() => { setState({ selectedDate: null }); }}
+			>
+				Reset date
+			</Button>
+		</DatePicker.Footer>
 	</DatePickerInput>
 </div>
 ```

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -14,7 +14,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>{`The selected date is ${state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
+		<span>The selected date is {state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
 		<Button ref={refs[0]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 		{state.isOpen && (
 			<Popover reference={refs[0].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>
@@ -48,7 +48,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>{`The selected date is ${state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
+		<span>The selected date is {state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
 		<Button ref={refs[1]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 			{state.isOpen && (
 				<Popover reference={refs[1].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -14,7 +14,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
+		<span>The selected date is {dateFunctions.format(state.selectedDate || new Date(), 'MM-dd-yyyy')}</span>
 		<Button ref={refs[0]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 		{state.isOpen && (
 			<Popover reference={refs[0].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>
@@ -23,7 +23,11 @@ state: { selectedDate: null }
 					setSelectedDate={(date) => setState({ selectedDate: date })}
 					dateFunctions={dateFunctions}
 					validate={() => true}
-				/>
+				>
+					<DatePicker.Footer>
+						<Button onClick={() => { setState({ selectedDate: null }); }}>Reset date</Button>
+					</DatePicker.Footer>
+				</DatePicker>
 			</Popover>
 		)}
 	</div>
@@ -38,7 +42,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>The selected date is {dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}</span>
+		<span>The selected date is {dateFunctions.format(state.selectedDate || new Date(), 'MM-dd-yyyy')}</span>
 		<Button ref={refs[1]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 			{state.isOpen && (
 				<Popover reference={refs[1].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -14,7 +14,10 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>The selected date is {dateFunctions.format(state.selectedDate || new Date(), 'MM-dd-yyyy')}</span>
+		{state.selectedDate == null ?
+			<span>No date selected.</span> :
+			<span>{`The selected date is ${dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
+		}
 		<Button ref={refs[0]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 		{state.isOpen && (
 			<Popover reference={refs[0].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>
@@ -24,8 +27,14 @@ state: { selectedDate: null }
 					dateFunctions={dateFunctions}
 					validate={() => true}
 				>
-					<DatePicker.Footer>
-						<Button onClick={() => { setState({ selectedDate: null }); }}>Reset date</Button>
+					<DatePicker.Footer display="flex" justifyContent="end">
+						<Button
+							variant="secondary"
+							height="22px"
+							onClick={() => { setState({ selectedDate: null }); }}
+						>
+							Reset date
+						</Button>
 					</DatePicker.Footer>
 				</DatePicker>
 			</Popover>
@@ -42,7 +51,10 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>The selected date is {dateFunctions.format(state.selectedDate || new Date(), 'MM-dd-yyyy')}</span>
+		{state.selectedDate == null ?
+			<span>No date selected.</span> :
+			<span>{`The selected date is ${dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
+		}
 		<Button ref={refs[1]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 			{state.isOpen && (
 				<Popover reference={refs[1].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>

--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -14,10 +14,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		{state.selectedDate == null ?
-			<span>No date selected.</span> :
-			<span>{`The selected date is ${dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
-		}
+		<span>{`The selected date is ${state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
 		<Button ref={refs[0]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 		{state.isOpen && (
 			<Popover reference={refs[0].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>
@@ -51,10 +48,7 @@ state: { selectedDate: null }
 ---
 <DatePickerDemo>
 	<div>
-		{state.selectedDate == null ?
-			<span>No date selected.</span> :
-			<span>{`The selected date is ${dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
-		}
+		<span>{`The selected date is ${state.selectedDate && dateFunctions.format(state.selectedDate, 'MM-dd-yyyy')}`}</span>
 		<Button ref={refs[1]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Date</Button>
 			{state.isOpen && (
 				<Popover reference={refs[1].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -320,6 +320,8 @@ const pages = [
 				title: 'Date Picker Input Variations',
 				content: pageLoader(() => import('./date-picker-input/variations.md')),
 				imports: {
+					Button,
+					DatePicker,
 					DatePickerInput,
 					dateFunctions: {
 						...dateFunctions,

--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -152,7 +152,9 @@ export function DatePickerInput({
 								dateFunctions={dateFunctions}
 								minDate={minDate}
 								maxDate={maxDate}
-							/>
+							>
+								{children}
+							</DatePicker>
 						</Styled.DateTime>
 					</Popover>
 				)}

--- a/components/date-picker/component.jsx
+++ b/components/date-picker/component.jsx
@@ -4,6 +4,7 @@ import { Box } from '../Box';
 import { Caret } from '../icons';
 import { colors } from '../shared-styles';
 import { dateFunctionProps } from './date-function-props';
+import { getConfigChild } from '../utils';
 import * as Styled from './styled';
 import { CalendarWeek } from './calendar-week';
 
@@ -35,13 +36,6 @@ function generateWeeks(month, dateFunctions) {
 	}
 
 	return weeks;
-}
-
-Footer.PropTypes = {
-	children: PropTypes.node,
-};
-function Footer({ children, ...props }) {
-	return <Box {...props}>{children}</Box>;
 }
 
 /** Standard date picker control (with support for many different date parsing libraries) */
@@ -136,7 +130,7 @@ class DatePicker extends Component {
 		} = this.props;
 		const { currentMonth, weeks } = this.state;
 
-		const footer = React.Children.toArray(children).filter(child => child.type === Footer);
+		const [footer] = getConfigChild(children, Footer.childConfigComponent);
 
 		return (
 			<Fragment>
@@ -200,6 +194,12 @@ class DatePicker extends Component {
 		);
 	}
 }
+
+function Footer({ children, ...props }) {
+	return <Box {...props}>{children}</Box>;
+}
+Footer.PropTypes = Box.PropTypes;
+Footer.childConfigComponent = 'Footer';
 
 DatePicker.Footer = Footer;
 

--- a/components/date-picker/component.jsx
+++ b/components/date-picker/component.jsx
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '../Box';
 import { Caret } from '../icons';
 import { colors } from '../shared-styles';
 import { dateFunctionProps } from './date-function-props';
@@ -36,8 +37,17 @@ function generateWeeks(month, dateFunctions) {
 	return weeks;
 }
 
+Footer.PropTypes = {
+	children: PropTypes.node,
+}
+function Footer({ children, ...props }) {
+	return <Box {...props}>
+		{children}
+	</Box>;
+}
+
 /** Standard date picker control (with support for many different date parsing libraries) */
-export class DatePicker extends Component {
+class DatePicker extends Component {
 	static propTypes = {
 		/** Sets the selected date */
 		selectedDate: PropTypes.instanceOf(Date),
@@ -55,6 +65,8 @@ export class DatePicker extends Component {
 		dateFunctions: dateFunctionProps,
 		minDate: PropTypes.instanceOf(Date),
 		maxDate: PropTypes.instanceOf(Date),
+		/** Use <DatePicker.Footer>...</DatePicker.Footer> to place components at the bottom of the DatePicker */
+		children: PropTypes.node,
 	};
 
 	UNSAFE_componentWillMount() {
@@ -122,8 +134,13 @@ export class DatePicker extends Component {
 			validate,
 			minDate,
 			maxDate,
+			children,
 		} = this.props;
 		const { currentMonth, weeks } = this.state;
+
+		const footer = React.Children.toArray(children).filter(
+			child => child.type === Footer,
+		);
 
 		return (
 			<Fragment>
@@ -182,7 +199,12 @@ export class DatePicker extends Component {
 						/>
 					))}
 				</Styled.Month>
+				{footer}
 			</Fragment>
 		);
 	}
 }
+
+DatePicker.Footer = Footer;
+
+export { DatePicker };

--- a/components/date-picker/component.jsx
+++ b/components/date-picker/component.jsx
@@ -39,11 +39,9 @@ function generateWeeks(month, dateFunctions) {
 
 Footer.PropTypes = {
 	children: PropTypes.node,
-}
+};
 function Footer({ children, ...props }) {
-	return <Box {...props}>
-		{children}
-	</Box>;
+	return <Box {...props}>{children}</Box>;
 }
 
 /** Standard date picker control (with support for many different date parsing libraries) */
@@ -138,9 +136,7 @@ class DatePicker extends Component {
 		} = this.props;
 		const { currentMonth, weeks } = this.state;
 
-		const footer = React.Children.toArray(children).filter(
-			child => child.type === Footer,
-		);
+		const footer = React.Children.toArray(children).filter(child => child.type === Footer);
 
 		return (
 			<Fragment>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faithlife/styled-ui",
-	"version": "6.8.1",
+	"version": "6.9.0",
 	"main": "dist/main.js",
 	"repository": "git@github.com:Faithlife/styled-ui.git",
 	"license": "MIT",


### PR DESCRIPTION
Adds a new component, `DatePicker.Footer`. When passed as a child to the `DatePicker` component, it is slotted into the bottom of the `DatePicker`. This allows custom buttons and other things.