### PR TITLE
Specify box-sizing in SimpleToast component

### DIFF
--- a/components/simple-toast/styled.jsx
+++ b/components/simple-toast/styled.jsx
@@ -48,6 +48,7 @@ export const transitionTime = 250; // milliseconds
 export const ToastContainer = styled.div`
 	/** Shared Styles */
 	display: grid;
+	box-sizing: content-box;
 	grid-auto-flow: column;
 	grid-column-gap: ${themeGet('space.3')};
 


### PR DESCRIPTION
This is the simplest change that could possibly work, and it can't make
any other cases worse.

Most CSS resets use something like:

```css
*, *:before, *:after {
  box-sizing: border-box;
}
```

With such a reset, this specificity will be sufficient.
Tested by adding such a reset to the `index.html` in this catalog project.

Fixes #487 