### PR TITLE
Remove explicit z-index on DatePickerInput.Popover

### DIFF
--- a/components/date-picker-input/component.jsx
+++ b/components/date-picker-input/component.jsx
@@ -141,7 +141,6 @@ export function DatePickerInput({
 						}}
 						placement="bottom-start"
 						padding="16px 20px"
-						zIndex={3}
 						{...popoverProps}
 					>
 						<Styled.DateTime>


### PR DESCRIPTION
The z-index on the Date Picker Input Popover is making it appear behind the Modal Backdrop when attached to the body. Removing to allow it to automatically get the same z-index as other pop-overs.