### PR TITLE
Replace DatePicker debounce with blur

### DIFF
--- a/catalog/date-picker/variations.md
+++ b/catalog/date-picker/variations.md
@@ -74,7 +74,7 @@ state: { selectedDateRange: null }
 ---
 <DatePickerDemo>
 	<div>
-		<span>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</span>
+		<span>The selected date range is {(state.selectedDateRange && state.selectedDateRange.start ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange && state.selectedDateRange.end ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</span>
 			<Button ref={refs[2]} onClick={() => setState({ isOpen: !state.isOpen })}>Select Dates</Button>
 			{state.isOpen && (
 				<Popover reference={refs[2].current} placement="bottom" styleOverrides={{ maxWidth: '1000px' }} onFocusAway={() => setState({ isOpen: false })}>
@@ -98,7 +98,7 @@ showSource: true
 state: { selectedDateRange: null, selectedDatePeriodIndex: null }
 ---
 <DatePickerDemo>
-	<div>The selected date range is {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</div>
+	<div>The selected date range is {(state.selectedDateRange && state.selectedDateRange.start ? dateFunctions.format(state.selectedDateRange.start, 'MM-dd-yyyy') : null)} to {(state.selectedDateRange && state.selectedDateRange.end ? dateFunctions.format(state.selectedDateRange.end, 'MM-dd-yyyy') : null)}</div>
 	<div>The selected date period index is <code>{state.selectedDatePeriodIndex === null ? "null" : state.selectedDatePeriodIndex}</code></div>
 	<Button ref={refs[3]} onClick={() => setState({ isOpen: !state.isOpen })} style={{ margin: "0.5rem 4rem" }}>Select Dates</Button>
 	{state.isOpen && (

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
 import { DatePicker } from '../date-picker';
 import { Input } from '../input';
 import { dateFunctionProps } from '../date-picker/date-function-props';
@@ -38,16 +37,10 @@ export class DatePeriodPicker extends PureComponent {
 		/** Takes a date as a parameter and returns false if that date is invalid */
 		validate: PropTypes.func,
 		dateFunctions: dateFunctionProps,
-		/** Debounce value for date inputs. Defaults to 500ms */
-		debounce: PropTypes.number,
 		disableEnumeratedRanges: PropTypes.bool,
 		disableCustomRange: PropTypes.bool,
 		disableCalendar: PropTypes.bool,
 		disableInferredDatePeriodIndex: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		debounce: 500,
 	};
 
 	static getDerivedStateFromProps(props, state) {
@@ -93,7 +86,7 @@ export class DatePeriodPicker extends PureComponent {
 		selectedDateRange: this.props.selectedDateRange,
 	};
 
-	parseAndUpdateDate = debounce((value, input) => {
+	parseAndUpdateDate = (value, input) => {
 		const parsedDate = this.props.parseDate(value, DATE_FORMAT_STRING, new Date());
 		if (parsedDate && !isNaN(parsedDate) && this.props.validate(parsedDate)) {
 			let selectedDate;
@@ -116,7 +109,7 @@ export class DatePeriodPicker extends PureComponent {
 				this.props.disableInferredDatePeriodIndex ? null : this.getDatePeriodIndex(selectedDate),
 			);
 		}
-	}, this.props.debounce);
+	};
 
 	handleInputValueChange = (value, input) => {
 		this.setState(state => ({ inputValues: { ...state.inputValues, [input]: value } }));

--- a/components/date-period-picker/component.jsx
+++ b/components/date-period-picker/component.jsx
@@ -113,7 +113,10 @@ export class DatePeriodPicker extends PureComponent {
 
 	handleInputValueChange = (value, input) => {
 		this.setState(state => ({ inputValues: { ...state.inputValues, [input]: value } }));
-		this.parseAndUpdateDate(value, input);
+	};
+
+	handleBlur = input => {
+		this.parseAndUpdateDate(this.state.inputValues[input], input);
 	};
 
 	/**
@@ -214,6 +217,7 @@ export class DatePeriodPicker extends PureComponent {
 								placeholder="mm/dd/yyyy"
 								value={start}
 								onChange={event => this.handleInputValueChange(event.target.value, 'start')}
+								onBlur={() => this.handleBlur('start')}
 								small
 							/>
 						</Styled.Label>
@@ -223,6 +227,7 @@ export class DatePeriodPicker extends PureComponent {
 								placeholder="mm/dd/yyyy"
 								value={end}
 								onChange={event => this.handleInputValueChange(event.target.value, 'end')}
+								onBlur={() => this.handleBlur('end')}
 								small
 							/>
 						</Styled.Label>


### PR DESCRIPTION
`Debounce` would create confusion for users when entering a date and have it automatically be parsed, this would cause the wrong date to be selected in some situations. Replaced the `debounce` with `blur` when parsing the date to resolve this issue.

Related flow: https://www.flowdock.com/app/logos/styled-ui/threads/8CZC8f3weq5zK0K0gvdkikcLVrq