### PR TITLE
Accordion custom indicator on left.

### DIFF
--- a/catalog/accordion/variations.md
+++ b/catalog/accordion/variations.md
@@ -70,12 +70,12 @@ For usability, it is suggested that custom indicators have `tabindex: -1` and no
 ```react
 plain: true
 showSource: true
-state: { expandedSections: [0, 2] }
+state: { expandedSections: [0, 3] }
 ---
 <AccordionDemo>
 	<Accordion hideArrows expandedSections={state.expandedSections} onExpansion={expandedSections => setState({expandedSections})}>
 		<Accordion.Item>
-			<Accordion.Header placeCustomIndicatorOnLeft renderCustomIndicator={({ isExpanded, onExpansion }) => (
+			<Accordion.Header renderLeftCustomIndicator={({ isExpanded, onExpansion }) => (
 					<Checkbox isChecked={isExpanded} onClick={onExpansion} tabIndex={-1} />
 				)
 			}>
@@ -103,8 +103,26 @@ state: { expandedSections: [0, 2] }
 			</Accordion.Panel>
 		</Accordion.Item>
 		<Accordion.Item>
-			<Accordion.Header>
+			<Accordion.Header
+				renderLeftCustomIndicator={({ isExpanded, onExpansion }) => (
+					<Checkbox isChecked={isExpanded} onClick={onExpansion} tabIndex={-1} />
+				)}
+				renderCustomIndicator={({ isExpanded, onExpansion }) => (
+					<Button variant="link" onClick={onExpansion}>{isExpanded ? 'Collapse' : 'Expand'}</Button>
+				)}
+			>
 				Section Three Title
+			</Accordion.Header>
+			<Accordion.Panel>
+				<Form>
+					<Input small placeholder="State/Province" />
+					<Input small placeholder="Country" />
+				</Form>
+			</Accordion.Panel>
+		</Accordion.Item>
+		<Accordion.Item>
+			<Accordion.Header>
+				Section Four Title
 			</Accordion.Header>
 			<Accordion.Panel>
 				<Form>

--- a/catalog/accordion/variations.md
+++ b/catalog/accordion/variations.md
@@ -75,7 +75,7 @@ state: { expandedSections: [0, 2] }
 <AccordionDemo>
 	<Accordion hideArrows expandedSections={state.expandedSections} onExpansion={expandedSections => setState({expandedSections})}>
 		<Accordion.Item>
-			<Accordion.Header renderCustomIndicator={({ isExpanded, onExpansion }) => (
+			<Accordion.Header placeCustomIndicatorOnLeft renderCustomIndicator={({ isExpanded, onExpansion }) => (
 					<Checkbox isChecked={isExpanded} onClick={onExpansion} tabIndex={-1} />
 				)
 			}>
@@ -89,7 +89,10 @@ state: { expandedSections: [0, 2] }
 			</Accordion.Panel>
 		</Accordion.Item>
 		<Accordion.Item>
-			<Accordion.Header>
+			<Accordion.Header renderCustomIndicator={({ isExpanded, onExpansion }) => (
+					<Checkbox isChecked={isExpanded} onClick={onExpansion} tabIndex={-1} />
+				)
+			}>
 				Section Two Title
 			</Accordion.Header>
 			<Accordion.Panel>

--- a/catalog/index.js
+++ b/catalog/index.js
@@ -182,6 +182,7 @@ const pages = [
 						border: 16px solid #f2f2f2;
 					`,
 					Checkbox,
+					Button,
 					Form: FormDemo,
 					Input,
 					Switch,

--- a/components/accordion/accordion-header.jsx
+++ b/components/accordion/accordion-header.jsx
@@ -11,7 +11,7 @@ export function AccordionHeader({
 	ariaLevel,
 	children,
 	renderCustomIndicator,
-	placeCustomIndicatorOnLeft = false,
+	renderLeftCustomIndicator,
 	subtitle,
 	...props
 }) {
@@ -86,9 +86,9 @@ export function AccordionHeader({
 							{isExpanded ? <ChevronDown /> : <ChevronRight />}
 						</Box>
 					)}
-					{renderCustomIndicator && placeCustomIndicatorOnLeft && (
+					{renderLeftCustomIndicator && (
 						<Box alignSelf="center">
-							{renderCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
+							{renderLeftCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
 						</Box>
 					)}
 					<ButtonContent>
@@ -118,7 +118,7 @@ export function AccordionHeader({
 					</ButtonContent>
 				</Button>
 			</Heading>
-			{renderCustomIndicator && !placeCustomIndicatorOnLeft && (
+			{renderCustomIndicator && (
 				<Box display="flex" gridRow={1} marginRight={variant === 'minimal' ? 4 : [5, 6]}>
 					{renderCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
 				</Box>
@@ -136,8 +136,8 @@ AccordionHeader.propTypes = {
 	ariaLevel: PropTypes.number,
 	/** Receives an isExpanded boolean value. */
 	renderCustomIndicator: PropTypes.func,
-	/** Default behavior is rendering the custom indicator on the right side of the header, this flag renders it to the left of the title. */
-	placeCustomIndicatorOnLeft: PropTypes.bool,
+	/** Receives an isExpanded boolean value. Can be used with `renderCustomIndicator`. */
+	renderLeftCustomIndicator: PropTypes.func,
 	...Box.propTypes,
 };
 

--- a/components/accordion/accordion-header.jsx
+++ b/components/accordion/accordion-header.jsx
@@ -11,6 +11,7 @@ export function AccordionHeader({
 	ariaLevel,
 	children,
 	renderCustomIndicator,
+	placeCustomIndicatorOnLeft = false,
 	subtitle,
 	...props
 }) {
@@ -85,8 +86,13 @@ export function AccordionHeader({
 							{isExpanded ? <ChevronDown /> : <ChevronRight />}
 						</Box>
 					)}
+					{renderCustomIndicator && placeCustomIndicatorOnLeft && (
+						<Box alignSelf="center">
+							{renderCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
+						</Box>
+					)}
 					<ButtonContent>
-						{children ? (
+						{children && (
 							<HoverableText
 								textStyle={variant === 'minimal' ? 'ui.14' : 'ui.16'}
 								display="grid"
@@ -96,8 +102,8 @@ export function AccordionHeader({
 							>
 								{children}
 							</HoverableText>
-						) : null}
-						{subtitle ? (
+						)}
+						{subtitle && (
 							<HoverableText
 								textStyle="ui.14"
 								display="block"
@@ -108,15 +114,15 @@ export function AccordionHeader({
 							>
 								{subtitle}
 							</HoverableText>
-						) : null}
+						)}
 					</ButtonContent>
 				</Button>
 			</Heading>
-			{renderCustomIndicator ? (
+			{renderCustomIndicator && !placeCustomIndicatorOnLeft && (
 				<Box display="flex" gridRow={1} marginRight={variant === 'minimal' ? 4 : [5, 6]}>
 					{renderCustomIndicator({ isExpanded, onExpansion: handleExpansion })}
 				</Box>
-			) : null}
+			)}
 		</Box>
 	);
 }
@@ -130,6 +136,8 @@ AccordionHeader.propTypes = {
 	ariaLevel: PropTypes.number,
 	/** Receives an isExpanded boolean value. */
 	renderCustomIndicator: PropTypes.func,
+	/** Default behavior is rendering the custom indicator on the right side of the header, this flag renders it to the left of the title. */
+	placeCustomIndicatorOnLeft: PropTypes.bool,
 	...Box.propTypes,
 };
 


### PR DESCRIPTION
This is the spec that I'm trying to implement, where each of these rows is an accordion header with a radio indicator to the left of the title as well as an indicator on the right (VISA card)

![image](https://user-images.githubusercontent.com/31995444/159803371-e8b14c60-5ec2-42be-bfb4-92f1475d52ca.png)
