### PR TITLE
fix: ImageWell preview position issue inside modal scrollarea

### DIFF
--- a/components/image-well/image-well-preview.jsx
+++ b/components/image-well/image-well-preview.jsx
@@ -11,7 +11,7 @@ export const WellPreview = styled(Box)`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	position: absolute;
+	position: relative;
 	border-radius: ${({ theme }) => theme.radii[2]};
 	border: none;
 


### PR DESCRIPTION
This addresses an issue where `ImageWell` previews within a `Modal` with a scrollarea would stick and exit the bounds of the containing `ImageWellBase` on scroll.